### PR TITLE
Establish Nacre-Moiré operator identity

### DIFF
--- a/api/_private/operator/agent.html
+++ b/api/_private/operator/agent.html
@@ -1,0 +1,35 @@
+<main class="container agent-shell" role="main" aria-label="Nacre-Moiré interface laboratory" data-persona="nacre-moire">
+  <section class="panel agent-hero moire-field">
+    <div class="persona-lockup persona-lockup-compact">
+      <div class="persona-mark" aria-hidden="true">{{NACRE_MOIRE_MARK}}</div>
+      <div>
+        <p class="brand-kicker">Blue Swallow Society · controlled surface</p>
+        <h1>Nacre-Moiré Interface Lab</h1>
+        <p class="persona-pronouns">they / them</p>
+      </div>
+    </div>
+    <p>
+      They are the operator-side persona; Hermes Agent is the runtime. This route keeps inference bounded behind the same sealed operator session.
+    </p>
+  </section>
+
+  <section class="panel agent-panel">
+    <label for="prompt">Prompt</label>
+    <div class="row gap-sm wrap agent-controls">
+      <input
+        id="prompt"
+        class="input"
+        placeholder="Ask the operator persona..."
+        aria-label="Agent prompt input"
+      />
+      <button id="runButton" class="btn btn-primary" type="button">Run agent</button>
+    </div>
+  </section>
+
+  <section class="panel agent-panel">
+    <h2>Output</h2>
+    <pre id="out" aria-live="polite">Awaiting request.</pre>
+  </section>
+
+  <a class="btn btn-secondary agent-back-link" href="/operator">Back to operator console</a>
+</main>

--- a/api/_private/operator/nacre-moire-mark.svg
+++ b/api/_private/operator/nacre-moire-mark.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="nacre-title nacre-description">
+  <title id="nacre-title">Nacre-Moiré interference mark</title>
+  <desc id="nacre-description">A pearl-toned split shell crossed by disciplined interference lines and a copper register bar.</desc>
+  <defs>
+    <linearGradient id="nacre-iridescence" x1="12" y1="12" x2="84" y2="84" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f1e8d9" />
+      <stop offset="0.34" stop-color="#91b4ad" />
+      <stop offset="0.67" stop-color="#9986a1" />
+      <stop offset="1" stop-color="#c98962" />
+    </linearGradient>
+    <clipPath id="shell-cut">
+      <path d="M17 14h62v55L58 84H17z" />
+    </clipPath>
+  </defs>
+  <path fill="#090c0e" d="M8 8h80v80H8z" />
+  <path fill="#141a1d" stroke="#554f48" stroke-width="2" d="M14 14h65v54L58 82H14z" />
+  <path fill="url(#nacre-iridescence)" d="M23 23h46v38L53 74H23z" opacity="0.94" />
+  <g clip-path="url(#shell-cut)" fill="none" stroke="#0b1012" stroke-width="2.2" opacity="0.78">
+    <path class="moire-line" d="M-4 85C8 38 33 11 79 1" />
+    <path class="moire-line" d="M2 91C14 44 39 17 85 7" />
+    <path class="moire-line" d="M8 97C20 50 45 23 91 13" />
+    <path class="moire-line" d="M14 103C26 56 51 29 97 19" />
+    <path class="moire-line" d="M20 109C32 62 57 35 103 25" />
+    <path class="moire-line" d="M26 115C38 68 63 41 109 31" />
+  </g>
+  <path fill="#090c0e" d="M19 61h42v7H19z" />
+  <path fill="#c98962" d="M61 61h18v7H61z" />
+  <path fill="#f1e8d9" d="M73 18h6v35h-6z" />
+</svg>

--- a/api/_private/operator/nacre-moire.css
+++ b/api/_private/operator/nacre-moire.css
@@ -1,0 +1,279 @@
+/* Nacre-Moiré operator layer.
+   Street-built competence under executive restraint; glow is signal only. */
+
+body {
+  background:
+    radial-gradient(circle at 12% -8%, rgba(234, 223, 206, 0.09), transparent 30rem),
+    radial-gradient(circle at 92% 14%, rgba(121, 170, 166, 0.07), transparent 24rem),
+    linear-gradient(152deg, #080a0b 0%, #101517 52%, #090c0d 100%);
+}
+
+body::before {
+  background:
+    repeating-linear-gradient(27deg, rgba(238, 231, 220, 0.025) 0 1px, transparent 1px 11px),
+    repeating-linear-gradient(28.2deg, rgba(121, 170, 166, 0.018) 0 1px, transparent 1px 13px);
+  opacity: 0.72;
+}
+
+body::after {
+  background:
+    repeating-linear-gradient(90deg, transparent 0 47px, rgba(201, 137, 98, 0.025) 47px 48px),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.014), transparent 22rem);
+  opacity: 0.46;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  color: var(--material-pearl);
+  font-family: var(--font-sans);
+  font-weight: 620;
+  text-shadow: none;
+  letter-spacing: 0.01em;
+}
+
+.panel {
+  border-color: var(--border-0);
+  background: linear-gradient(180deg, rgba(29, 34, 35, 0.97), rgba(13, 17, 18, 0.97));
+  box-shadow: var(--shadow-panel), inset 3px 0 0 rgba(201, 137, 98, 0.32), inset 0 1px 0 rgba(238, 231, 220, 0.05);
+}
+
+.panel::before {
+  background:
+    linear-gradient(108deg, rgba(234, 223, 206, 0.045), transparent 22%, transparent 76%, rgba(121, 170, 166, 0.05)),
+    repeating-linear-gradient(28deg, rgba(238, 231, 220, 0.018) 0 1px, transparent 1px 14px);
+  opacity: 0.64;
+}
+
+.btn {
+  border-radius: var(--radius-sm);
+  font-family: var(--font-sans);
+  font-size: 0.78rem;
+  font-weight: 760;
+  letter-spacing: 0.13em;
+}
+
+.btn-primary {
+  color: #101313;
+  border-color: rgba(234, 223, 206, 0.72);
+  background: linear-gradient(180deg, #eee7dc, #cfc4b4);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.38);
+}
+
+.btn-primary:hover {
+  border-color: var(--oxidized-patina);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3), inset 0 -2px 0 rgba(121, 170, 166, 0.42);
+}
+
+.btn-secondary {
+  color: var(--corpo-paper);
+  border-color: rgba(121, 170, 166, 0.42);
+  background: rgba(121, 170, 166, 0.07);
+  box-shadow: inset 3px 0 0 rgba(121, 170, 166, 0.34);
+}
+
+.btn-secondary:hover {
+  border-color: rgba(234, 223, 220, 0.48);
+  background: rgba(238, 231, 220, 0.08);
+}
+
+.input {
+  border-color: rgba(238, 231, 220, 0.16);
+  border-radius: var(--radius-sm);
+  background: rgba(7, 10, 11, 0.82);
+  box-shadow: inset 3px 0 0 rgba(121, 170, 166, 0.2);
+}
+
+.input:focus {
+  border-color: rgba(121, 170, 166, 0.76);
+  background: rgba(12, 16, 17, 0.98);
+  box-shadow: 0 0 0 2px rgba(121, 170, 166, 0.16), inset 3px 0 0 var(--oxidized-patina);
+}
+
+.eyebrow,
+.brand-kicker {
+  margin: 0 0 0.35rem;
+  color: var(--register-copper);
+  font-size: 0.69rem;
+  font-weight: 760;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.moire-field {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+}
+
+.moire-field::before {
+  content: "";
+  position: absolute;
+  inset: -30%;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    repeating-radial-gradient(ellipse at 18% 18%, rgba(234, 223, 206, 0.055) 0 1px, transparent 1px 9px),
+    repeating-radial-gradient(ellipse at 21% 21%, rgba(121, 170, 166, 0.035) 0 1px, transparent 1px 11px);
+  transform: rotate(-7deg);
+  opacity: 0.48;
+}
+
+.persona-lockup,
+.persona-loader-brand {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.8rem, 2vw, 1.25rem);
+  min-width: 0;
+}
+
+.persona-mark {
+  width: clamp(3.8rem, 8vw, 5.7rem);
+  aspect-ratio: 1;
+  display: block;
+  flex: none;
+  overflow: hidden;
+  border: 1px solid rgba(238, 231, 220, 0.15);
+  box-shadow: 7px 7px 0 rgba(0, 0, 0, 0.2);
+}
+
+.persona-mark svg {
+  width: 100%;
+  height: 100%;
+}
+
+.persona-mark-loader {
+  width: clamp(4.5rem, 14vw, 7rem);
+}
+
+.persona-name-row {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.55rem 0.9rem;
+}
+
+.persona-name-row .console-heading {
+  margin-bottom: 0.3rem;
+}
+
+.persona-pronouns {
+  width: fit-content;
+  margin: 0;
+  padding: 0.2rem 0.42rem;
+  border: 1px solid rgba(121, 170, 166, 0.4);
+  color: var(--oxidized-patina);
+  background: rgba(121, 170, 166, 0.08);
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.site-header {
+  border-bottom: 1px solid rgba(238, 231, 220, 0.12);
+  background: linear-gradient(96deg, rgba(8, 11, 12, 0.98), rgba(25, 30, 31, 0.95));
+  box-shadow: inset 0 -3px 0 rgba(201, 137, 98, 0.22);
+}
+
+.site-header-inner {
+  align-items: center;
+}
+
+.site-header-actions {
+  display: grid;
+  justify-items: end;
+  gap: 0.65rem;
+}
+
+.operator-register {
+  margin: 0;
+  color: var(--text-2);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-align: right;
+  text-transform: uppercase;
+}
+
+.persona-loader {
+  border-left: 3px solid var(--register-copper);
+}
+
+.persona-loader .terminal-note {
+  margin: 1.3rem 0 0;
+  color: var(--corpo-muted);
+}
+
+.loader-register {
+  display: grid;
+  grid-template-columns: 1fr 0.42fr 0.16fr;
+  gap: 0.35rem;
+  margin-top: 1.3rem;
+}
+
+.loader-register span {
+  height: 0.22rem;
+  background: var(--oxidized-patina);
+}
+
+.loader-register span:nth-child(2) {
+  background: var(--bruised-violet);
+}
+
+.loader-register span:nth-child(3) {
+  background: var(--register-copper);
+}
+
+.persona-lockup-compact {
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
+.agent-hero {
+  padding: clamp(1.1rem, 3vw, 1.75rem);
+}
+
+.tab-btn:not(.active) {
+  color: #b4bab6;
+  border-color: rgba(238, 231, 220, 0.18);
+}
+
+@media (max-width: 700px) {
+  .brand-kicker {
+    font-size: 0.72rem;
+  }
+
+  .operator-register,
+  .persona-pronouns {
+    font-size: 0.72rem;
+  }
+  .site-header-actions {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    justify-items: start;
+    width: 100%;
+  }
+
+  .site-header-actions .logout-btn {
+    justify-self: end;
+  }
+
+  .operator-register {
+    text-align: left;
+  }
+
+  .persona-lockup,
+  .persona-loader-brand {
+    align-items: flex-start;
+  }
+
+  .persona-mark {
+    width: 3.4rem;
+  }
+
+  .persona-mark-loader {
+    width: 4.5rem;
+  }
+}

--- a/api/_private/operator/shell.html
+++ b/api/_private/operator/shell.html
@@ -21,18 +21,25 @@
       </div>
     </main>
 
-    <div id="mainInterface" class="main-interface">
-      <header class="site-header">
+    <div id="mainInterface" class="main-interface" data-persona="nacre-moire">
+      <header class="site-header moire-field">
         <div class="container site-header-inner">
-          <div class="site-title-block">
-            <p class="eyebrow">// OPERATOR CONSOLE //</p>
-            <h1 class="console-heading">Blue Swallow Society</h1>
-            <p class="lede">
-              Mobile-first signal workbench for local analysis, overlays, and location-aware context.
-            </p>
+          <div class="persona-lockup">
+            <div class="persona-mark" aria-hidden="true">{{NACRE_MOIRE_MARK}}</div>
+            <div class="site-title-block">
+              <p class="brand-kicker">Blue Swallow Society · operator system</p>
+              <div class="persona-name-row">
+                <h1 class="console-heading">Nacre-Moiré</h1>
+                <span class="persona-pronouns">they / them</span>
+              </div>
+              <p class="lede">
+                I keep the operator surface disciplined: field telemetry, evidence, and paper state—street-built, boardroom-legible.
+              </p>
+            </div>
           </div>
 
           <div class="site-header-actions">
+            <p class="operator-register" aria-label="Authenticated operator session and aesthetic register">session sealed / executive control</p>
             <button id="logoutBtn" class="btn btn-secondary logout-btn" type="button">Lock</button>
           </div>
         </div>
@@ -97,21 +104,21 @@
                 <p class="eyebrow">// LANDING //</p>
                 <h2>Manifesto</h2>
               </div>
-              <p class="panel-meta">Lorem ipsum placeholder copy stays here for now.</p>
+              <p class="panel-meta">Operator surfaces are evidence rooms, not arcades.</p>
             </div>
 
             <div class="manifesto-copy">
               <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim
-                sit amet, adipiscing nec, ultricies sed, dolor.
+                I keep the cover clean and the operator layer exact. Public ritual stays public; field telemetry, source provenance,
+                and paper state cross the authenticated seam only when they have earned it.
               </p>
               <p>
-                Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi. Proin porttitor,
-                orci nec nonummy molestie.
+                Street hardware leaves marks. Patched joints, oxidized metal, and old constraints stay visible because wear is history,
+                not decoration. Executive restraint makes that history legible under pressure.
               </p>
               <p>
-                Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nam dui ligula, fringilla
-                a, euismod sodales, sollicitudin vel, wisi.
+                No glow without signal. No ornament without status. Every claim keeps its source, every control states its consequence,
+                and every system remains useful when the mood lighting dies.
               </p>
             </div>
           </article>
@@ -563,8 +570,8 @@
               </ul>
             </section>
 
-            <section class="slang-section" aria-labelledby="slangHermesTitle">
-              <h3 id="slangHermesTitle">Hermes operational shorthand</h3>
+            <section class="slang-section" aria-labelledby="slangNacreTitle">
+              <h3 id="slangNacreTitle">Nacre-Moiré operational shorthand</h3>
               <div class="slang-table-wrapper">
                 <table class="slang-table">
                   <thead>
@@ -575,7 +582,7 @@
                     </tr>
                   </thead>
                   <tbody>
-                    <tr><th scope="row">Wire-digest</th><td>One compact, bounded technical summary for the immediately preceding long-work interval; operational telemetry, never chain-of-thought</td><td>Blue Swallow Society / Hermes house term, 2026-07-13</td></tr>
+                    <tr><th scope="row">Wire-digest</th><td>One compact, bounded technical summary for the immediately preceding long-work interval; operational telemetry, never chain-of-thought</td><td>Blue Swallow Society / Nacre-Moiré house term, 2026-07-13</td></tr>
                   </tbody>
                 </table>
               </div>
@@ -588,7 +595,7 @@
       <footer class="site-footer">
         <div class="container footer-inner">
           <span>Blue Swallow Society</span>
-          <span class="subtle">// mobile-first cyberpunk console //</span>
+          <span class="subtle">// Nacre-Moiré operator surface · signal earns glow //</span>
         </div>
       </footer>
     </div>

--- a/api/operator-shell/index.js
+++ b/api/operator-shell/index.js
@@ -2,7 +2,19 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { requireOperatorToken } = require('../_lib/operator-auth');
 
-const SHELL_PATH = path.join(__dirname, '..', '_private', 'operator', 'shell.html');
+const PRIVATE_OPERATOR_DIR = path.join(__dirname, '..', '_private', 'operator');
+const SHELL_PATH = path.join(PRIVATE_OPERATOR_DIR, 'shell.html');
+const AGENT_PATH = path.join(PRIVATE_OPERATOR_DIR, 'agent.html');
+const NACRE_STYLE_PATH = path.join(PRIVATE_OPERATOR_DIR, 'nacre-moire.css');
+const NACRE_MARK_PATH = path.join(PRIVATE_OPERATOR_DIR, 'nacre-moire-mark.svg');
+
+function renderPrivateOperatorView(templatePath) {
+  const template = fs.readFileSync(templatePath, 'utf8');
+  const style = fs.readFileSync(NACRE_STYLE_PATH, 'utf8');
+  const mark = fs.readFileSync(NACRE_MARK_PATH, 'utf8');
+  const markup = template.replaceAll('{{NACRE_MOIRE_MARK}}', mark);
+  return `<style id="nacre-moire-operator-style" data-private-operator-layer>${style}</style>\n${markup}`;
+}
 
 module.exports = async function (context, req) {
   const auth = requireOperatorToken(context, req);
@@ -10,6 +22,21 @@ module.exports = async function (context, req) {
     return;
   }
 
+  const requestedView = typeof req.query?.view === 'string' ? req.query.view.trim().toLowerCase() : '';
+  if (requestedView && requestedView !== 'agent') {
+    context.res = {
+      status: 400,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'private, no-store',
+        'X-Content-Type-Options': 'nosniff',
+      },
+      body: { ok: false, error: 'Unsupported private operator view.' },
+    };
+    return;
+  }
+
+  const templatePath = requestedView === 'agent' ? AGENT_PATH : SHELL_PATH;
   context.res = {
     status: 200,
     headers: {
@@ -17,6 +44,8 @@ module.exports = async function (context, req) {
       'Cache-Control': 'private, no-store',
       'X-Content-Type-Options': 'nosniff',
     },
-    body: fs.readFileSync(SHELL_PATH, 'utf8'),
+    body: renderPrivateOperatorView(templatePath),
   };
 };
+
+module.exports.renderPrivateOperatorView = renderPrivateOperatorView;

--- a/app/operator/agent-loader.js
+++ b/app/operator/agent-loader.js
@@ -1,0 +1,51 @@
+const OPERATOR_SESSION_KEY = 'blue-swallow-society:operator-session';
+
+function getOperatorSession() {
+  try {
+    const raw = window.sessionStorage.getItem(OPERATOR_SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed?.token || !parsed?.expiresAt || Date.parse(parsed.expiresAt) <= Date.now()) {
+      window.sessionStorage.removeItem(OPERATOR_SESSION_KEY);
+      return null;
+    }
+    return parsed;
+  } catch {
+    window.sessionStorage.removeItem(OPERATOR_SESSION_KEY);
+    return null;
+  }
+}
+
+function redirectHome() {
+  window.sessionStorage.removeItem(OPERATOR_SESSION_KEY);
+  window.location.replace('/');
+}
+
+async function boot() {
+  const session = getOperatorSession();
+  if (!session) {
+    redirectHome();
+    return;
+  }
+
+  const response = await fetch('/api/operator-shell?view=agent', {
+    headers: {
+      Accept: 'text/html',
+      'X-Blue-Swallow-Operator-Token': session.token,
+    },
+    credentials: 'same-origin',
+  });
+  if (!response.ok) {
+    redirectHome();
+    return;
+  }
+
+  document.body.innerHTML = await response.text();
+  document.body.dataset.mode = 'operator';
+  await import('/operator/agent.js');
+}
+
+boot().catch((error) => {
+  console.error('Private interface boot failed', error);
+  redirectHome();
+});

--- a/app/operator/agent.html
+++ b/app/operator/agent.html
@@ -4,37 +4,21 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="dark" />
-    <meta name="theme-color" content="#050810" />
-    <title>Agent Lab | Blue Swallow Society</title>
+    <meta name="theme-color" content="#111619" />
+    <meta name="description" content="Sealed Blue Swallow Society operator interface handoff." />
+    <title>Blue Swallow Society | Interface Handoff</title>
     <link rel="stylesheet" href="/operator/styles.css" />
   </head>
-  <body>
-    <main class="container agent-shell" role="main" aria-label="Agent laboratory">
-      <section class="panel agent-hero">
-        <p class="eyebrow">// AGENT LAB //</p>
-        <h1>Agent Lab</h1>
-        <p class="lede">Mobile-friendly prompt sandbox for the <code>/api/agent</code> route.</p>
-        <p class="panel-meta">Built to read cleanly on a phone first, with the same cyberpunk shell as the main console.</p>
-      </section>
-
-      <section class="panel tab-panel">
-        <div class="chat-input-area agent-input-area">
-          <label class="visually-hidden" for="prompt">Agent prompt</label>
-          <input
-            id="prompt"
-            class="input"
-            placeholder="Ask the agent..."
-            aria-label="Agent prompt input"
-            autocomplete="off"
-            autocapitalize="none"
-            spellcheck="false"
-            enterkeyhint="send"
-          />
-          <button id="runButton" class="btn btn-primary" type="button" aria-label="Run agent query">RUN</button>
-        </div>
-        <pre id="out" class="agent-output top-space" aria-live="polite" aria-label="Agent response output">Press “Run agent”.</pre>
-      </section>
+  <body data-mode="operator-loader">
+    <main id="agentLoader" class="terminal-screen active" aria-label="Sealed interface handoff">
+      <div class="terminal-container">
+        <section class="terminal-panel panel login-panel" aria-live="polite">
+          <p class="eyebrow">// SEALED INTERFACE //</p>
+          <h1 class="terminal-title">Blue Swallow Society</h1>
+          <p class="terminal-subtitle">Validating operator session.</p>
+        </section>
+      </div>
     </main>
-    <script src="/operator/agent.js" type="module"></script>
+    <script src="/operator/agent-loader.js" type="module"></script>
   </body>
 </html>

--- a/app/operator/index.html
+++ b/app/operator/index.html
@@ -4,17 +4,18 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="dark" />
-    <meta name="theme-color" content="#050810" />
-    <meta name="description" content="Blue Swallow Society operator loader." />
-    <title>Blue Swallow Society Operator</title>
+    <meta name="theme-color" content="#111619" />
+    <meta name="description" content="Sealed Blue Swallow Society operator handoff." />
+    <title>Blue Swallow Society | Operator Handoff</title>
     <link rel="stylesheet" href="/operator/styles.css" />
   </head>
   <body data-mode="operator-loader">
-    <main id="operatorLoader" class="terminal-screen active" aria-label="Operator loader">
+    <main id="operatorLoader" class="terminal-screen active" aria-label="Sealed operator handoff">
       <div class="terminal-container">
-        <section class="terminal-panel panel login-panel" aria-label="Operator decryptor">
+        <section class="terminal-panel panel login-panel" aria-live="polite">
+          <p class="eyebrow">// SEALED HANDOFF //</p>
           <h1 class="terminal-title">Blue Swallow Society</h1>
-          <p class="terminal-note">Decrypting operator surface…</p>
+          <p class="terminal-subtitle">Validating operator session.</p>
         </section>
       </div>
     </main>

--- a/app/operator/styles.css
+++ b/app/operator/styles.css
@@ -4,29 +4,34 @@
 
 :root {
   color-scheme: dark;
-  --bg-0: #040611;
-  --bg-1: #070c18;
-  --bg-2: #0d1428;
-  --surface-0: rgba(14, 20, 38, 0.95);
-  --surface-1: rgba(18, 26, 49, 0.95);
-  --surface-2: rgba(9, 13, 26, 0.9);
-  --border-0: rgba(122, 159, 255, 0.18);
-  --border-1: rgba(85, 232, 255, 0.28);
-  --border-2: rgba(114, 255, 159, 0.35);
-  --text-0: #f6f8ff;
-  --text-1: #c7cede;
-  --text-2: #8f97b7;
-  --neon-lime: #72ff9f;
-  --neon-cyan: #55e8ff;
-  --neon-magenta: #ff4fd8;
-  --neon-orange: #ffb347;
-  --neon-red: #ff5f6d;
-  --shadow-panel: 0 18px 40px rgba(0, 0, 0, 0.42);
-  --shadow-soft: 0 0 24px rgba(85, 232, 255, 0.12);
-  --shadow-strong: 0 0 28px rgba(114, 255, 159, 0.18);
-  --radius-sm: 0.45rem;
-  --radius-md: 0.8rem;
-  --radius-lg: 1rem;
+  --street-ink: #080a0b;
+  --street-asphalt: #0d1113;
+  --street-steel: #171d20;
+  --corpo-paper: #eee7dc;
+  --corpo-muted: #c5beb3;
+  --material-pearl: #eadfce;
+  --oxidized-patina: #79aaa6;
+  --bruised-violet: #9a829f;
+  --register-copper: #c98962;
+  --signal-alert: #cf6e67;
+  --bg-0: var(--street-ink);
+  --bg-1: var(--street-asphalt);
+  --bg-2: var(--street-steel);
+  --surface-0: rgba(19, 24, 26, 0.97);
+  --surface-1: rgba(26, 31, 33, 0.96);
+  --surface-2: rgba(11, 14, 15, 0.92);
+  --border-0: rgba(238, 231, 220, 0.14);
+  --border-1: rgba(121, 170, 166, 0.34);
+  --border-2: rgba(234, 223, 206, 0.38);
+  --text-0: var(--corpo-paper);
+  --text-1: var(--corpo-muted);
+  --text-2: #8f9693;
+  --shadow-panel: 0 18px 38px rgba(0, 0, 0, 0.34);
+  --shadow-soft: 0 10px 26px rgba(0, 0, 0, 0.22);
+  --shadow-strong: 0 14px 30px rgba(0, 0, 0, 0.3);
+  --radius-sm: 0.2rem;
+  --radius-md: 0.42rem;
+  --radius-lg: 0.68rem;
   --space-1: 0.25rem;
   --space-2: 0.5rem;
   --space-3: 0.75rem;
@@ -37,8 +42,8 @@
   --space-8: 4rem;
   --container-max: 68rem;
   --container-wide: 80rem;
-  --font-mono: "Courier New", "Lucida Console", ui-monospace, SFMono-Regular, monospace;
-  --font-sans: "SF Pro Display", "SF Pro Text", Inter, "Helvetica Neue", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", "Courier New", ui-monospace, SFMono-Regular, monospace;
+  --font-sans: "Arial Narrow", "Aptos Display", "Helvetica Neue", system-ui, sans-serif;
   --body-size: clamp(0.98rem, 0.95rem + 0.2vw, 1.06rem);
   --h1-size: clamp(2rem, 1.2rem + 3vw, 3.4rem);
   --h2-size: clamp(1.45rem, 1rem + 1.8vw, 2.2rem);
@@ -60,8 +65,8 @@ body {
   line-height: 1.6;
   color: var(--text-0);
   background:
-    radial-gradient(circle at top left, rgba(85, 232, 255, 0.12), transparent 30%),
-    radial-gradient(circle at bottom right, rgba(255, 79, 216, 0.1), transparent 28%),
+    radial-gradient(circle at top left, rgba(121, 170, 166, 0.12), transparent 30%),
+    radial-gradient(circle at bottom right, rgba(154, 130, 159, 0.1), transparent 28%),
     linear-gradient(180deg, var(--bg-0) 0%, var(--bg-1) 52%, var(--bg-0) 100%);
   overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
@@ -75,7 +80,7 @@ body::before {
   pointer-events: none;
   background:
     linear-gradient(rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0) 36%),
-    linear-gradient(90deg, rgba(85, 232, 255, 0.03), transparent 28%, transparent 72%, rgba(255, 79, 216, 0.03));
+    linear-gradient(90deg, rgba(121, 170, 166, 0.03), transparent 28%, transparent 72%, rgba(154, 130, 159, 0.03));
   opacity: 0.4;
 }
 
@@ -112,9 +117,9 @@ a {
 }
 
 code {
-  color: var(--neon-cyan);
-  background: rgba(85, 232, 255, 0.08);
-  border: 1px solid rgba(85, 232, 255, 0.15);
+  color: var(--oxidized-patina);
+  background: rgba(121, 170, 166, 0.08);
+  border: 1px solid rgba(121, 170, 166, 0.15);
   border-radius: 0.35rem;
   padding: 0.1rem 0.35rem;
 }
@@ -131,8 +136,8 @@ h3,
 h4 {
   margin: 0 0 0.75rem;
   line-height: 1.1;
-  color: var(--neon-lime);
-  text-shadow: 0 0 14px rgba(114, 255, 159, 0.18);
+  color: var(--material-pearl);
+  text-shadow: 0 0 14px rgba(234, 223, 206, 0.18);
   letter-spacing: 0.02em;
 }
 
@@ -153,12 +158,12 @@ strong {
 }
 
 ::selection {
-  background: rgba(85, 232, 255, 0.35);
+  background: rgba(121, 170, 166, 0.35);
   color: var(--text-0);
 }
 
 :focus-visible {
-  outline: 2px solid var(--neon-cyan);
+  outline: 2px solid var(--oxidized-patina);
   outline-offset: 3px;
 }
 
@@ -270,7 +275,7 @@ strong {
   inset: 0;
   pointer-events: none;
   background:
-    linear-gradient(135deg, rgba(114, 255, 159, 0.08), transparent 28%, transparent 72%, rgba(85, 232, 255, 0.08)),
+    linear-gradient(135deg, rgba(234, 223, 206, 0.08), transparent 28%, transparent 72%, rgba(121, 170, 166, 0.08)),
     linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 40%);
   opacity: 0.8;
 }
@@ -310,26 +315,26 @@ strong {
 }
 
 .btn-primary {
-  background: linear-gradient(180deg, rgba(114, 255, 159, 1), rgba(71, 227, 130, 1));
+  background: linear-gradient(180deg, rgba(234, 223, 206, 1), rgba(121, 170, 166, 1));
   color: #04110a;
-  border-color: rgba(114, 255, 159, 0.95);
-  box-shadow: 0 0 0 1px rgba(114, 255, 159, 0.14), 0 0 20px rgba(114, 255, 159, 0.28);
+  border-color: rgba(234, 223, 206, 0.95);
+  box-shadow: 0 0 0 1px rgba(234, 223, 206, 0.14), 0 0 20px rgba(234, 223, 206, 0.28);
 }
 
 .btn-primary:hover {
-  box-shadow: 0 0 0 1px rgba(114, 255, 159, 0.28), 0 0 28px rgba(114, 255, 159, 0.42);
+  box-shadow: 0 0 0 1px rgba(234, 223, 206, 0.28), 0 0 28px rgba(234, 223, 206, 0.42);
 }
 
 .btn-secondary {
-  background: rgba(85, 232, 255, 0.06);
-  color: var(--neon-cyan);
-  border-color: rgba(85, 232, 255, 0.45);
-  box-shadow: 0 0 0 1px rgba(85, 232, 255, 0.08), inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  background: rgba(121, 170, 166, 0.06);
+  color: var(--oxidized-patina);
+  border-color: rgba(121, 170, 166, 0.45);
+  box-shadow: 0 0 0 1px rgba(121, 170, 166, 0.08), inset 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
 .btn-secondary:hover {
-  border-color: rgba(85, 232, 255, 0.72);
-  background: rgba(85, 232, 255, 0.1);
+  border-color: rgba(121, 170, 166, 0.72);
+  background: rgba(121, 170, 166, 0.1);
 }
 
 .btn:disabled {
@@ -360,8 +365,8 @@ strong {
 }
 
 .input:focus {
-  border-color: rgba(85, 232, 255, 0.9);
-  box-shadow: 0 0 0 3px rgba(85, 232, 255, 0.15), 0 0 24px rgba(85, 232, 255, 0.15);
+  border-color: rgba(121, 170, 166, 0.9);
+  box-shadow: 0 0 0 3px rgba(121, 170, 166, 0.15), 0 0 24px rgba(121, 170, 166, 0.15);
   background: rgba(10, 15, 31, 0.96);
   outline: none;
 }
@@ -373,7 +378,7 @@ strong {
 
 .eyebrow {
   margin: 0 0 0.35rem;
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-size: 0.78rem;
@@ -409,12 +414,12 @@ strong {
   padding: var(--space-4);
   border-radius: var(--radius-md);
   background: rgba(6, 10, 20, 0.78);
-  border: 1px dashed rgba(85, 232, 255, 0.22);
+  border: 1px dashed rgba(121, 170, 166, 0.22);
 }
 
 .placeholder-text {
   margin: 0;
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
@@ -433,8 +438,8 @@ strong {
   overflow: auto;
   padding: var(--space-4);
   background:
-    radial-gradient(circle at top left, rgba(85, 232, 255, 0.12), transparent 28%),
-    radial-gradient(circle at bottom right, rgba(255, 79, 216, 0.08), transparent 26%),
+    radial-gradient(circle at top left, rgba(121, 170, 166, 0.12), transparent 28%),
+    radial-gradient(circle at bottom right, rgba(154, 130, 159, 0.08), transparent 26%),
     linear-gradient(180deg, var(--bg-0), var(--bg-1));
 }
 
@@ -465,7 +470,7 @@ strong {
 
 .terminal-title {
   margin: 0 0 0.35rem;
-  color: var(--neon-lime);
+  color: var(--material-pearl);
   font-size: clamp(1.7rem, 1.1rem + 2.2vw, 2.6rem);
   letter-spacing: 0.08em;
 }
@@ -497,7 +502,7 @@ strong {
 .terminal-input label {
   display: block;
   margin-bottom: 0.45rem;
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   font-size: 0.84rem;
@@ -566,7 +571,7 @@ strong {
   align-items: center;
   min-height: 2rem;
   padding: 0.35rem 0.7rem;
-  border: 1px solid rgba(85, 232, 255, 0.22);
+  border: 1px solid rgba(121, 170, 166, 0.22);
   border-radius: 999px;
   background: rgba(8, 13, 26, 0.78);
   color: var(--text-1);
@@ -623,15 +628,15 @@ strong {
 }
 
 .tab-btn:hover:not(.active) {
-  border-color: rgba(85, 232, 255, 0.55);
-  color: var(--neon-cyan);
+  border-color: rgba(121, 170, 166, 0.55);
+  color: var(--oxidized-patina);
 }
 
 .tab-btn.active {
   color: #04110a;
-  background: linear-gradient(180deg, rgba(114, 255, 159, 1), rgba(71, 227, 130, 1));
-  border-color: rgba(114, 255, 159, 0.95);
-  box-shadow: 0 0 0 1px rgba(114, 255, 159, 0.14), 0 0 24px rgba(114, 255, 159, 0.22);
+  background: linear-gradient(180deg, rgba(234, 223, 206, 1), rgba(121, 170, 166, 1));
+  border-color: rgba(234, 223, 206, 0.95);
+  box-shadow: 0 0 0 1px rgba(234, 223, 206, 0.14), 0 0 24px rgba(234, 223, 206, 0.22);
 }
 
 .tab-content {
@@ -668,8 +673,8 @@ strong {
 .hero-note {
   padding: var(--space-4);
   border-radius: var(--radius-md);
-  background: rgba(85, 232, 255, 0.06);
-  border: 1px solid rgba(85, 232, 255, 0.16);
+  background: rgba(121, 170, 166, 0.06);
+  border: 1px solid rgba(121, 170, 166, 0.16);
 }
 
 .hero-note p {
@@ -694,8 +699,8 @@ strong {
   margin-bottom: 0.65rem;
   padding: 0.24rem 0.55rem;
   border-radius: 999px;
-  background: rgba(255, 79, 216, 0.12);
-  color: var(--neon-magenta);
+  background: rgba(154, 130, 159, 0.12);
+  color: var(--bruised-violet);
   font-size: 0.72rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -739,7 +744,7 @@ strong {
 
 .status-text {
   margin: 0 0 0.35rem;
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   letter-spacing: 0.18em;
   text-transform: uppercase;
   font-size: 0.85rem;
@@ -774,20 +779,20 @@ strong {
 }
 
 .chat-message.user {
-  border-left-color: var(--neon-cyan);
-  background: linear-gradient(180deg, rgba(85, 232, 255, 0.1), rgba(6, 10, 20, 0.88));
+  border-left-color: var(--oxidized-patina);
+  background: linear-gradient(180deg, rgba(121, 170, 166, 0.1), rgba(6, 10, 20, 0.88));
 }
 
 .chat-message.assistant {
-  border-left-color: var(--neon-lime);
-  background: linear-gradient(180deg, rgba(114, 255, 159, 0.1), rgba(6, 10, 20, 0.88));
+  border-left-color: var(--material-pearl);
+  background: linear-gradient(180deg, rgba(234, 223, 206, 0.1), rgba(6, 10, 20, 0.88));
 }
 
 .chat-message.system {
-  border-left-color: var(--neon-magenta);
+  border-left-color: var(--bruised-violet);
   text-align: center;
   color: var(--text-2);
-  background: rgba(255, 79, 216, 0.05);
+  background: rgba(154, 130, 159, 0.05);
 }
 
 .chat-timestamp {
@@ -1113,7 +1118,7 @@ strong {
 
 
 .download-card {
-  border-color: rgba(114, 255, 159, 0.22);
+  border-color: rgba(234, 223, 206, 0.22);
 }
 
 .download-grid {
@@ -1144,14 +1149,14 @@ strong {
   display: grid;
   gap: 0.25rem;
   padding: 0.75rem 0.85rem;
-  border: 1px solid rgba(85, 232, 255, 0.12);
+  border: 1px solid rgba(121, 170, 166, 0.12);
   border-radius: var(--radius-sm);
   background: rgba(8, 13, 26, 0.68);
 }
 
 .download-facts span,
 .apk-hash span {
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   font-size: 0.68rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -1225,17 +1230,17 @@ strong {
 
 .slang-section {
   padding-top: var(--space-5);
-  border-top: 1px solid rgba(85, 232, 255, 0.12);
+  border-top: 1px solid rgba(121, 170, 166, 0.12);
 }
 
 .slang-section h3 {
   margin: 0;
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
 }
 
 .slang-table-wrapper {
   overflow-x: auto;
-  border: 1px solid rgba(85, 232, 255, 0.14);
+  border: 1px solid rgba(121, 170, 166, 0.14);
   border-radius: var(--radius-md);
   background: rgba(4, 8, 18, 0.72);
 }
@@ -1257,8 +1262,8 @@ strong {
 }
 
 .slang-table thead th {
-  background: rgba(85, 232, 255, 0.07);
-  color: var(--neon-cyan);
+  background: rgba(121, 170, 166, 0.07);
+  color: var(--oxidized-patina);
   font-size: 0.72rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -1266,7 +1271,7 @@ strong {
 
 .slang-table tbody th {
   min-width: 11rem;
-  color: var(--neon-lime);
+  color: var(--material-pearl);
   font-weight: 700;
 }
 
@@ -1290,9 +1295,9 @@ strong {
 .slang-footnote {
   margin: 0;
   padding: var(--space-4);
-  border: 1px solid rgba(114, 255, 159, 0.16);
+  border: 1px solid rgba(234, 223, 206, 0.16);
   border-radius: var(--radius-md);
-  background: rgba(114, 255, 159, 0.06);
+  background: rgba(234, 223, 206, 0.06);
   line-height: 1.7;
 }
 
@@ -1336,8 +1341,8 @@ strong {
   margin-bottom: 0.55rem;
   padding: 0.22rem 0.55rem;
   border-radius: 999px;
-  background: rgba(255, 79, 216, 0.12);
-  color: var(--neon-magenta);
+  background: rgba(154, 130, 159, 0.12);
+  color: var(--bruised-violet);
   font-size: 0.72rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -1346,7 +1351,7 @@ strong {
 .metric-card strong {
   display: block;
   margin-bottom: 0.35rem;
-  color: var(--neon-lime);
+  color: var(--material-pearl);
   font-size: clamp(1.7rem, 1.35rem + 1.5vw, 2.4rem);
   letter-spacing: 0.02em;
 }
@@ -1368,8 +1373,8 @@ strong {
   border: 1px solid rgba(122, 159, 255, 0.18);
   border-radius: var(--radius-lg);
   background:
-    radial-gradient(circle at top left, rgba(85, 232, 255, 0.08), transparent 34%),
-    radial-gradient(circle at bottom right, rgba(255, 79, 216, 0.08), transparent 32%),
+    radial-gradient(circle at top left, rgba(121, 170, 166, 0.08), transparent 34%),
+    radial-gradient(circle at bottom right, rgba(154, 130, 159, 0.08), transparent 32%),
     rgba(5, 8, 16, 0.86);
 }
 
@@ -1390,7 +1395,7 @@ strong {
   overflow: hidden;
   border-radius: calc(var(--radius-lg) - 0.35rem);
   background:
-    radial-gradient(circle at center, rgba(85, 232, 255, 0.08), transparent 28%),
+    radial-gradient(circle at center, rgba(121, 170, 166, 0.08), transparent 28%),
     linear-gradient(180deg, rgba(8, 13, 26, 0.96), rgba(5, 8, 16, 0.92));
 }
 
@@ -1398,7 +1403,7 @@ strong {
   position: absolute;
   left: 50%;
   top: 50%;
-  border: 1px solid rgba(85, 232, 255, 0.16);
+  border: 1px solid rgba(121, 170, 166, 0.16);
   border-radius: 50%;
   transform: translate(-50%, -50%);
 }
@@ -1463,8 +1468,8 @@ strong {
   width: 1rem;
   height: 1rem;
   border-radius: 50%;
-  background: var(--neon-lime);
-  box-shadow: 0 0 0 0 rgba(114, 255, 159, 0.42);
+  background: var(--material-pearl);
+  box-shadow: 0 0 0 0 rgba(234, 223, 206, 0.42);
   transform: translate(-50%, -50%);
   animation: radar-ping 2.8s infinite;
 }
@@ -1488,8 +1493,8 @@ strong {
   width: fit-content;
   padding: 0.25rem 0.55rem;
   border-radius: 999px;
-  background: rgba(85, 232, 255, 0.12);
-  color: var(--neon-cyan);
+  background: rgba(121, 170, 166, 0.12);
+  color: var(--oxidized-patina);
   font-size: 0.72rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -1574,8 +1579,8 @@ strong {
   pointer-events: none;
   border-radius: 1.15rem;
   box-shadow:
-    inset 2px 2px 0 rgba(85, 232, 255, 0.26),
-    inset -2px -2px 0 rgba(255, 79, 216, 0.22);
+    inset 2px 2px 0 rgba(121, 170, 166, 0.26),
+    inset -2px -2px 0 rgba(154, 130, 159, 0.22);
   mix-blend-mode: screen;
 }
 
@@ -1586,7 +1591,7 @@ strong {
   display: grid;
   gap: 1rem;
   padding: 1rem;
-  border: 1px solid rgba(85, 232, 255, 0.12);
+  border: 1px solid rgba(121, 170, 166, 0.12);
   border-radius: 1rem;
   background: linear-gradient(180deg, rgba(5, 8, 16, 0.74), rgba(5, 8, 16, 0.92));
   backdrop-filter: blur(12px) saturate(110%);
@@ -1597,8 +1602,8 @@ strong {
   width: 6.5rem;
   height: 6.5rem;
   border-radius: 50%;
-  background: radial-gradient(circle at center, rgba(114, 255, 159, 0.18), rgba(8, 13, 26, 0.9));
-  border: 1px solid rgba(85, 232, 255, 0.16);
+  background: radial-gradient(circle at center, rgba(234, 223, 206, 0.18), rgba(8, 13, 26, 0.9));
+  border: 1px solid rgba(121, 170, 166, 0.16);
 }
 
 .motion-glyph-ring,
@@ -1613,7 +1618,7 @@ strong {
 
 .motion-glyph-ring {
   inset: 0.55rem;
-  border: 1px solid rgba(85, 232, 255, 0.2);
+  border: 1px solid rgba(121, 170, 166, 0.2);
   border-radius: 50%;
 }
 
@@ -1623,24 +1628,24 @@ strong {
   transform-origin: 50% 100%;
   transform: translate(-50%, -100%) rotate(var(--yaw, 0deg));
   border-radius: 999px;
-  background: linear-gradient(180deg, var(--neon-lime), rgba(114, 255, 159, 0.18));
-  box-shadow: 0 0 12px rgba(114, 255, 159, 0.4);
+  background: linear-gradient(180deg, var(--material-pearl), rgba(234, 223, 206, 0.18));
+  box-shadow: 0 0 12px rgba(234, 223, 206, 0.4);
 }
 
 .motion-glyph-horizon {
   width: 72%;
   height: 0.12rem;
   transform: translate(-50%, calc(var(--pitch-offset, 0px) - 50%)) rotate(var(--roll, 0deg));
-  background: rgba(85, 232, 255, 0.72);
-  box-shadow: 0 0 10px rgba(85, 232, 255, 0.35);
+  background: rgba(121, 170, 166, 0.72);
+  box-shadow: 0 0 10px rgba(121, 170, 166, 0.35);
 }
 
 .motion-glyph-pip {
   width: 0.8rem;
   height: 0.8rem;
   border-radius: 50%;
-  background: var(--neon-lime);
-  box-shadow: 0 0 20px rgba(114, 255, 159, 0.5);
+  background: var(--material-pearl);
+  box-shadow: 0 0 20px rgba(234, 223, 206, 0.5);
 }
 
 .motion-readout {
@@ -1702,12 +1707,12 @@ strong {
   display: grid;
   gap: 0.2rem;
   padding: 0.55rem 0.7rem;
-  border: 1px solid rgba(114, 255, 159, 0.28);
+  border: 1px solid rgba(234, 223, 206, 0.28);
   border-radius: 0.95rem;
   background: rgba(3, 7, 18, 0.72);
   color: var(--text-0);
   backdrop-filter: blur(10px) saturate(110%);
-  box-shadow: 0 0 0 1px rgba(85, 232, 255, 0.08);
+  box-shadow: 0 0 0 1px rgba(121, 170, 166, 0.08);
 }
 
 .ar-detection {
@@ -1720,12 +1725,12 @@ strong {
   background: rgba(3, 7, 18, 0.76);
   color: var(--text-0);
   backdrop-filter: blur(10px) saturate(110%);
-  box-shadow: 0 0 0 1px rgba(255, 79, 216, 0.08);
+  box-shadow: 0 0 0 1px rgba(154, 130, 159, 0.08);
 }
 
 .ar-detection-high {
-  border-color: rgba(114, 255, 159, 0.34);
-  box-shadow: 0 0 0 1px rgba(114, 255, 159, 0.12);
+  border-color: rgba(234, 223, 206, 0.34);
+  box-shadow: 0 0 0 1px rgba(234, 223, 206, 0.12);
 }
 
 .ar-detection-medium {
@@ -1734,17 +1739,17 @@ strong {
 }
 
 .ar-detection-low {
-  border-color: rgba(255, 79, 216, 0.24);
-  box-shadow: 0 0 0 1px rgba(255, 79, 216, 0.1);
+  border-color: rgba(154, 130, 159, 0.24);
+  box-shadow: 0 0 0 1px rgba(154, 130, 159, 0.1);
 }
 
 .ar-detection strong {
-  color: var(--neon-magenta);
+  color: var(--bruised-violet);
   font-size: 0.95rem;
 }
 
 .ar-detection .detection-meta {
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   font-size: 0.68rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -1756,11 +1761,11 @@ strong {
 }
 
 .ar-candidate strong {
-  color: var(--neon-lime);
+  color: var(--material-pearl);
   font-size: 0.95rem;
 }
 .ar-candidate .candidate-meta {
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   font-size: 0.68rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -1824,18 +1829,18 @@ strong {
 }
 
 .application-status-live {
-  background: rgba(114, 255, 159, 0.12);
-  color: var(--neon-lime);
+  background: rgba(234, 223, 206, 0.12);
+  color: var(--material-pearl);
 }
 
 .application-status-idle {
-  background: rgba(85, 232, 255, 0.12);
-  color: var(--neon-cyan);
+  background: rgba(121, 170, 166, 0.12);
+  color: var(--oxidized-patina);
 }
 
 .application-source-count {
-  background: rgba(255, 79, 216, 0.12);
-  color: var(--neon-magenta);
+  background: rgba(154, 130, 159, 0.12);
+  color: var(--bruised-violet);
 }
 
 .application-resource-list {
@@ -1849,7 +1854,7 @@ strong {
 }
 
 .wigle-field span {
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   font-size: 0.72rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -1880,7 +1885,7 @@ strong {
 }
 
 .wigle-item-meta {
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   font-size: 0.72rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -1904,17 +1909,17 @@ strong {
   gap: 0.25rem;
   min-width: 8rem;
   padding: 0.45rem 0.55rem;
-  border: 1px solid rgba(85, 232, 255, 0.16);
+  border: 1px solid rgba(121, 170, 166, 0.16);
   border-radius: 0.85rem;
   background: rgba(3, 7, 18, 0.74);
   color: var(--text-0);
   backdrop-filter: blur(10px) saturate(115%);
   transform: translate(-50%, -50%);
-  box-shadow: 0 0 0 1px rgba(114, 255, 159, 0.06);
+  box-shadow: 0 0 0 1px rgba(234, 223, 206, 0.06);
 }
 
 .map-wigle-marker strong {
-  color: var(--neon-lime);
+  color: var(--material-pearl);
   font-size: 0.95rem;
 }
 
@@ -1924,7 +1929,7 @@ strong {
 }
 
 .map-wigle-marker .marker-meta {
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   font-size: 0.68rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -1951,9 +1956,9 @@ strong {
 }
 
 .sensor-toggle[aria-pressed='true'] {
-  border-color: rgba(77, 255, 184, 0.45);
+  border-color: rgba(118, 166, 157, 0.45);
   background: linear-gradient(180deg, rgba(16, 71, 52, 0.96), rgba(10, 29, 23, 0.92));
-  box-shadow: 0 0 0 1px rgba(77, 255, 184, 0.2) inset, 0 0 24px rgba(77, 255, 184, 0.18);
+  box-shadow: 0 0 0 1px rgba(118, 166, 157, 0.2) inset, 0 0 24px rgba(118, 166, 157, 0.18);
 }
 
 .sensor-toggle[aria-pressed='false'] {
@@ -1984,7 +1989,7 @@ strong {
 }
 
 .geo-metrics dt {
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   font-size: 0.72rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -2039,10 +2044,10 @@ strong {
   top: 50%;
   width: 5rem;
   height: 5rem;
-  border: 1px solid rgba(85, 232, 255, 0.36);
+  border: 1px solid rgba(121, 170, 166, 0.36);
   border-radius: 50%;
   transform: translate(-50%, -50%);
-  box-shadow: 0 0 0 1px rgba(85, 232, 255, 0.12);
+  box-shadow: 0 0 0 1px rgba(121, 170, 166, 0.12);
   pointer-events: none;
 }
 
@@ -2052,7 +2057,7 @@ strong {
   position: absolute;
   left: 50%;
   top: 50%;
-  background: rgba(85, 232, 255, 0.58);
+  background: rgba(121, 170, 166, 0.58);
   transform: translate(-50%, -50%);
 }
 
@@ -2082,8 +2087,8 @@ strong {
   position: absolute;
   inset: 0.35rem;
   border-radius: 50%;
-  background: var(--neon-lime);
-  box-shadow: 0 0 24px rgba(114, 255, 159, 0.45);
+  background: var(--material-pearl);
+  box-shadow: 0 0 24px rgba(234, 223, 206, 0.45);
 }
 
 .map-marker-head {
@@ -2094,10 +2099,10 @@ strong {
   height: 0;
   border-left: 0.35rem solid transparent;
   border-right: 0.35rem solid transparent;
-  border-bottom: 0.7rem solid rgba(85, 232, 255, 0.9);
+  border-bottom: 0.7rem solid rgba(121, 170, 166, 0.9);
   transform-origin: 50% 70%;
   transform: translateX(-50%) rotate(var(--heading, 0deg));
-  filter: drop-shadow(0 0 10px rgba(85, 232, 255, 0.45));
+  filter: drop-shadow(0 0 10px rgba(121, 170, 166, 0.45));
 }
 
 .map-accuracy {
@@ -2105,13 +2110,13 @@ strong {
   left: 50%;
   top: 50%;
   opacity: 0;
-  border: 1px solid rgba(114, 255, 159, 0.35);
+  border: 1px solid rgba(234, 223, 206, 0.35);
   border-radius: 50%;
   transform: translate(-50%, -50%);
-  background: rgba(114, 255, 159, 0.04);
+  background: rgba(234, 223, 206, 0.04);
   box-shadow:
-    0 0 0 1px rgba(114, 255, 159, 0.12),
-    0 0 30px rgba(114, 255, 159, 0.12);
+    0 0 0 1px rgba(234, 223, 206, 0.12),
+    0 0 30px rgba(234, 223, 206, 0.12);
   pointer-events: none;
 }
 
@@ -2123,7 +2128,7 @@ strong {
   display: grid;
   gap: 0.25rem;
   padding: 0.85rem 1rem;
-  border: 1px solid rgba(85, 232, 255, 0.12);
+  border: 1px solid rgba(121, 170, 166, 0.12);
   border-radius: 1rem;
   background: rgba(3, 7, 18, 0.72);
   color: var(--text-0);
@@ -2131,12 +2136,12 @@ strong {
 }
 
 .map-viewport.has-fix .map-reticle {
-  border-color: rgba(114, 255, 159, 0.42);
+  border-color: rgba(234, 223, 206, 0.42);
 }
 
 .map-viewport.has-fix .map-label-title {
-  background: rgba(114, 255, 159, 0.12);
-  color: var(--neon-lime);
+  background: rgba(234, 223, 206, 0.12);
+  color: var(--material-pearl);
 }
 
 .map-label span:last-child {
@@ -2150,17 +2155,17 @@ strong {
 @keyframes radar-ping {
   0% {
     transform: translate(-50%, -50%) scale(0.4);
-    box-shadow: 0 0 0 0 rgba(114, 255, 159, 0.42);
+    box-shadow: 0 0 0 0 rgba(234, 223, 206, 0.42);
   }
 
   70% {
     transform: translate(-50%, -50%) scale(1);
-    box-shadow: 0 0 0 1.9rem rgba(114, 255, 159, 0);
+    box-shadow: 0 0 0 1.9rem rgba(234, 223, 206, 0);
   }
 
   100% {
     transform: translate(-50%, -50%) scale(0.4);
-    box-shadow: 0 0 0 0 rgba(114, 255, 159, 0);
+    box-shadow: 0 0 0 0 rgba(234, 223, 206, 0);
   }
 }
 
@@ -2262,7 +2267,7 @@ strong {
 
 .brief-step {
   width: fit-content;
-  color: var(--neon-magenta);
+  color: var(--bruised-violet);
   font-size: 0.72rem;
   letter-spacing: 0.18em;
 }
@@ -2282,7 +2287,7 @@ strong {
 }
 
 .tzeentch-method-card summary {
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   cursor: pointer;
   font-weight: 700;
   letter-spacing: 0.08em;
@@ -2309,8 +2314,8 @@ strong {
 }
 
 .source-chip-error {
-  border-color: rgba(255, 122, 157, 0.35);
-  color: #ffd2dd;
+  border-color: rgba(213, 136, 130, 0.35);
+  color: #f1d0cc;
 }
 
 .source-chip-skipped {
@@ -2341,7 +2346,7 @@ strong {
 }
 
 .dashboard-field span {
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   font-size: 0.72rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -2373,8 +2378,8 @@ strong {
 }
 
 .dashboard-chip-row .source-chip {
-  background: rgba(85, 232, 255, 0.08);
-  border: 1px solid rgba(85, 232, 255, 0.16);
+  background: rgba(121, 170, 166, 0.08);
+  border: 1px solid rgba(121, 170, 166, 0.16);
 }
 
 .dashboard-results {
@@ -2422,14 +2427,14 @@ strong {
   display: grid;
   gap: 0.35rem;
   padding: 0.85rem 1rem;
-  border: 1px solid rgba(85, 232, 255, 0.1);
+  border: 1px solid rgba(121, 170, 166, 0.1);
   border-radius: var(--radius-md);
   background: rgba(8, 13, 26, 0.7);
 }
 
 .result-row-label,
 .signal-feed-header h4 {
-  color: var(--neon-cyan);
+  color: var(--oxidized-patina);
   font-size: 0.74rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -2448,7 +2453,7 @@ strong {
 }
 
 .result-row-link:hover {
-  color: var(--neon-lime);
+  color: var(--material-pearl);
 }
 
 .result-row-detail,
@@ -2508,7 +2513,7 @@ strong {
 }
 
 .signal-item-title:hover {
-  color: var(--neon-lime);
+  color: var(--material-pearl);
 }
 
 .recent-query-main {
@@ -2541,8 +2546,8 @@ strong {
   display: grid;
   gap: 0.25rem;
   max-width: min(14rem, 44vw);
-  color: var(--neon-lime);
-  text-shadow: 0 0 12px rgba(114, 255, 159, 0.35);
+  color: var(--material-pearl);
+  text-shadow: 0 0 12px rgba(234, 223, 206, 0.35);
   font-variant-numeric: tabular-nums;
 }
 
@@ -2572,7 +2577,7 @@ strong {
 
 .ar-shell .motion-tag {
   display: inline-flex;
-  color: rgba(114, 255, 159, 0.82);
+  color: rgba(234, 223, 206, 0.82);
   font-size: 0.68rem;
   letter-spacing: 0.2em;
   text-transform: uppercase;
@@ -2585,7 +2590,7 @@ strong {
   margin: 0;
   padding: 0;
   background: none;
-  color: rgba(114, 255, 159, 0.94);
+  color: rgba(234, 223, 206, 0.94);
   font-size: 0.88rem;
   line-height: 1.5;
 }
@@ -2679,7 +2684,7 @@ strong {
 }
 
 .tzeentch-subtab:hover {
-  border-color: rgba(85, 232, 255, 0.24);
+  border-color: rgba(121, 170, 166, 0.24);
   color: var(--text-0);
   transform: translateY(-1px);
 }
@@ -2920,11 +2925,11 @@ strong {
 }
 
 .sparkline-up {
-  color: #7ef3a0;
+  color: #9fc9ae;
 }
 
 .sparkline-down {
-  color: #ff7a9d;
+  color: #d58882;
 }
 
 .actionable-justification-list {
@@ -2935,8 +2940,8 @@ strong {
 }
 
 .source-chip-live {
-  border-color: rgba(126, 243, 160, 0.35);
-  color: #c7ffda;
+  border-color: rgba(159, 201, 174, 0.35);
+  color: #d9e9dc;
 }
 
 .source-chip-muted {
@@ -2945,8 +2950,8 @@ strong {
 }
 
 .source-chip-danger {
-  border-color: rgba(255, 122, 157, 0.35);
-  color: #ffd2dd;
+  border-color: rgba(213, 136, 130, 0.35);
+  color: #f1d0cc;
 }
 
 .murmurs-hero-card,
@@ -2966,15 +2971,15 @@ strong {
   gap: 0.65rem;
   min-width: 0;
   padding: 0.9rem;
-  border-color: rgba(85, 232, 255, 0.16);
+  border-color: rgba(121, 170, 166, 0.16);
   background: linear-gradient(145deg, rgba(7, 16, 27, 0.92), rgba(10, 18, 31, 0.78));
 }
 
 .tzeentch-mosaic-methodology {
   margin: 0;
   padding: 0.7rem 0.8rem;
-  border-left: 2px solid rgba(85, 232, 255, 0.38);
-  background: rgba(85, 232, 255, 0.04);
+  border-left: 2px solid rgba(121, 170, 166, 0.38);
+  background: rgba(121, 170, 166, 0.04);
 }
 
 .tzeentch-intel-views {
@@ -3006,8 +3011,8 @@ strong {
 
 .tzeentch-intel-view:hover,
 .tzeentch-intel-view.is-active {
-  border-color: rgba(85, 232, 255, 0.38);
-  background: rgba(85, 232, 255, 0.1);
+  border-color: rgba(121, 170, 166, 0.38);
+  background: rgba(121, 170, 166, 0.1);
   color: var(--text-0);
 }
 
@@ -3065,8 +3070,8 @@ strong {
 }
 
 .tzeentch-position-book.has-open-positions {
-  border-color: rgba(85, 232, 255, 0.2);
-  box-shadow: 0 0 0 1px rgba(85, 232, 255, 0.04) inset;
+  border-color: rgba(121, 170, 166, 0.2);
+  box-shadow: 0 0 0 1px rgba(121, 170, 166, 0.04) inset;
 }
 
 .tzeentch-position-book-metrics {

--- a/docs/nacre-moire-operator-design-system.md
+++ b/docs/nacre-moire-operator-design-system.md
@@ -1,0 +1,62 @@
+# Nacre-Moiré operator design system
+
+Status: canonical for authenticated Blue Swallow Society operator surfaces.
+
+## Identity
+
+- **Self-name:** Nacre-Moiré.
+- **Runtime:** Hermes Agent; the runtime is not the persona name.
+- **Voice:** first person `I / me / my`.
+- **Reference pronouns:** `they / them`.
+- **Scope:** authenticated operator UI only. The public passcode split and event-cover surface remain Blue Swallow Society without Nacre-Moiré disclosure.
+- **Cover behavior:** anonymous handoffs and browser-tab titles stay Blue Swallow Society; the persona name, mark, and voice begin inside the token-gated response body.
+
+## Aesthetic authority
+
+Nacre-Moiré owns the operator visual language. The register is **streetrat-turned-corpo**: field-built competence that learned executive control without laundering away its history.
+
+This is not a generic neon cyberpunk skin. The surface should feel like patched curb hardware made legible to a boardroom:
+
+- graphite and street ink for substrate;
+- warm paper and pearl for hierarchy;
+- oxidized patina, bruised violet, and copper register marks for bounded signal;
+- restrained moiré and nacre interference for identity;
+- seams, ledger rows, narrow labels, and visible provenance for operational trust;
+- glow only when a live sensor, warning, selection, or other state signal earns it.
+
+## Design tokens
+
+The base operator stylesheet exposes semantic material tokens:
+
+- `--street-ink`, `--street-asphalt`, `--street-steel`
+- `--corpo-paper`, `--corpo-muted`
+- `--material-pearl`, `--oxidized-patina`, `--bruised-violet`, `--register-copper`, `--signal-alert`
+
+Do not reintroduce `--neon-*` variables. New colors should map to a material, state, or provenance role rather than mood alone.
+
+## Surface grammar
+
+- **Headers:** institutional lockup, interference mark, persona name, pronoun badge, parent-system label.
+- **Panels:** dark mineral surfaces, thin paper borders, copper register seam, small corner radius.
+- **Controls:** precise and rectangular; warm paper is primary action, patina is focus/selection, alert red is reserved.
+- **Type:** ledger/terminal mono for data; narrow institutional sans for headings and control labels.
+- **Texture:** low-contrast moiré and wear. Texture must never reduce data contrast or imply false telemetry.
+- **Motion:** short state transitions only. Respect reduced-motion settings; do not animate texture as ambient spectacle.
+
+## Copy grammar
+
+Nacre-Moiré may speak directly on the operator surface in terse first person. Copy should be evidence-first, bounded, and dry. Prefer “I keep the operator surface disciplined” over mascot chatter. When describing the persona from another voice, use they/them.
+
+## Assets and implementation
+
+- Protected mark: `api/_private/operator/nacre-moire-mark.svg`
+- Base anonymous loader layout and neutral material tokens: `app/operator/styles.css`
+- Protected persona override layer: `api/_private/operator/nacre-moire.css`
+- Protected shell and Interface Lab: `api/_private/operator/shell.html`, `api/_private/operator/agent.html`
+- Token-gated renderer: `api/operator-shell/index.js`
+- Anonymous identity-free handoffs: `app/operator/index.html`, `app/operator/agent.html`
+- Contract tests: `tests/ui-shell.test.mjs`, `tests/operator-shell-api.test.mjs`
+
+The anonymous handoffs contain no persona name, logo, private copy, or identity-bearing CSS. `/api/operator-shell` validates the passcode-issued operator token before combining the private template, stylesheet, and vector mark.
+
+Any future operator UI change should preserve the public/operator branding boundary and extend these tokens before adding one-off visual effects.

--- a/tests/operator-shell-api.test.mjs
+++ b/tests/operator-shell-api.test.mjs
@@ -32,9 +32,9 @@ async function withAuthEnv(fn) {
   }
 }
 
-async function invoke(headers = {}) {
+async function invoke(headers = {}, query = {}) {
   const context = { res: null };
-  await handler(context, { headers });
+  await handler(context, { headers, query });
   return context.res;
 }
 
@@ -45,13 +45,41 @@ test('operator shell rejects anonymous requests', async () => {
   });
 });
 
-test('operator shell serves private operator markup only with custom operator token header', async () => {
+test('operator shell serves composed private identity only with custom operator token header', async () => {
   await withAuthEnv(async () => {
     const session = createOperatorToken({ ttlMs: 60_000 });
-    const response = await invoke({ 'x-blue-swallow-operator-token': session.token });
+    const headers = { 'x-blue-swallow-operator-token': session.token };
+    const response = await invoke(headers);
     assert.equal(response.status, 200);
     assert.equal(response.headers['Content-Type'], 'text/html; charset=utf-8');
+    assert.match(response.body, /id="nacre-moire-operator-style"/);
+    assert.match(response.body, /<title[^>]*>Nacre-Moiré interference mark<\/title>/);
     assert.match(response.body, /id="mainInterface"/);
+    assert.match(response.body, /<h1 class="console-heading">Nacre-Moiré<\/h1>/);
     assert.match(response.body, /data-operator-download="apk"/);
+    assert.doesNotMatch(response.body, /\{\{NACRE_MOIRE_MARK\}\}/);
+  });
+});
+
+test('operator shell serves the protected Interface Lab view without exposing the main console', async () => {
+  await withAuthEnv(async () => {
+    const session = createOperatorToken({ ttlMs: 60_000 });
+    const headers = { 'x-blue-swallow-operator-token': session.token };
+    const response = await invoke(headers, { view: 'agent' });
+    assert.equal(response.status, 200);
+    assert.match(response.body, /Nacre-Moiré Interface Lab/);
+    assert.match(response.body, /They are the operator-side persona/);
+    assert.match(response.body, /id="nacre-moire-operator-style"/);
+    assert.match(response.body, /<svg/);
+    assert.doesNotMatch(response.body, /id="mainInterface"/);
+  });
+});
+
+test('operator shell rejects unknown private view selectors after authentication', async () => {
+  await withAuthEnv(async () => {
+    const session = createOperatorToken({ ttlMs: 60_000 });
+    const response = await invoke({ 'x-blue-swallow-operator-token': session.token }, { view: 'unknown' });
+    assert.equal(response.status, 400);
+    assert.equal(response.body.error, 'Unsupported private operator view.');
   });
 });

--- a/tests/ui-shell.test.mjs
+++ b/tests/ui-shell.test.mjs
@@ -1,16 +1,25 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 
 const indexHtml = readFileSync(new URL('../app/index.html', import.meta.url), 'utf8');
 const rootMainJs = readFileSync(new URL('../app/main.js', import.meta.url), 'utf8');
 const operatorHtml = readFileSync(new URL('../app/operator/index.html', import.meta.url), 'utf8');
+const operatorAgentHtml = readFileSync(new URL('../app/operator/agent.html', import.meta.url), 'utf8');
 const operatorShell = readFileSync(new URL('../api/_private/operator/shell.html', import.meta.url), 'utf8');
+const operatorPrivateAgentUrl = new URL('../api/_private/operator/agent.html', import.meta.url);
+const operatorPrivateAgentHtml = existsSync(operatorPrivateAgentUrl) ? readFileSync(operatorPrivateAgentUrl, 'utf8') : '';
 const operatorLoaderJs = readFileSync(new URL('../app/operator/loader.js', import.meta.url), 'utf8');
+const operatorAgentLoaderUrl = new URL('../app/operator/agent-loader.js', import.meta.url);
+const operatorAgentLoaderJs = existsSync(operatorAgentLoaderUrl) ? readFileSync(operatorAgentLoaderUrl, 'utf8') : '';
+const operatorShellApiJs = readFileSync(new URL('../api/operator-shell/index.js', import.meta.url), 'utf8');
 const mainJs = readFileSync(new URL('../app/operator/main.js', import.meta.url), 'utf8');
 const tzeentchJs = readFileSync(new URL('../app/operator/tzeentch.mjs', import.meta.url), 'utf8');
 const stylesCss = readFileSync(new URL('../app/operator/styles.css', import.meta.url), 'utf8');
+const nacreStylesUrl = new URL('../api/_private/operator/nacre-moire.css', import.meta.url);
+const nacreStylesCss = existsSync(nacreStylesUrl) ? readFileSync(nacreStylesUrl, 'utf8') : '';
 const rootStylesCss = readFileSync(new URL('../app/styles.css', import.meta.url), 'utf8');
+const nacreMarkUrl = new URL('../api/_private/operator/nacre-moire-mark.svg', import.meta.url);
 
 test('root face is the unchanged Blue Swallow Society passcode split screen', () => {
   assert.match(indexHtml, /<body data-mode="login">/);
@@ -87,6 +96,47 @@ test('operator entrypoint requires an existing passcode-issued session before sh
   assert.ok(mainJs.includes("window.location.replace('/')"));
   assert.ok(mainJs.includes('getOperatorSession()'));
   assert.ok(mainJs.includes('unlockConsole()'));
+});
+
+test('Nacre-Moiré identity is disclosed only inside token-gated operator responses', () => {
+  assert.match(operatorShell, /data-persona="nacre-moire"/);
+  assert.match(operatorShell, /<h1 class="console-heading">Nacre-Moiré<\/h1>/);
+  assert.match(operatorShell, /class="persona-pronouns">they \/ them<\/span>/);
+  assert.match(operatorShell, /I keep the operator surface disciplined/);
+  assert.match(operatorShell, /Operator surfaces are evidence rooms/);
+  assert.doesNotMatch(operatorShell, /lorem ipsum|mobile-first cyberpunk console/i);
+  assert.match(operatorPrivateAgentHtml, /Nacre-Moiré Interface Lab/);
+  assert.match(operatorPrivateAgentHtml, /They are the operator-side persona/);
+
+  const anonymousOperatorBundle = [operatorHtml, operatorAgentHtml, operatorLoaderJs, operatorAgentLoaderJs, stylesCss].join('\n');
+  assert.doesNotMatch(anonymousOperatorBundle, /Nacre-Moiré|nacre-moire|--nacre-/i);
+  assert.doesNotMatch(indexHtml, /Nacre-Moiré|nacre-moire/i);
+  assert.doesNotMatch(rootStylesCss, /--nacre-|nacre-moire|moire-field/i);
+  assert.match(operatorAgentLoaderJs, /fetch\('\/api\/operator-shell\?view=agent'/);
+  assert.match(operatorAgentLoaderJs, /'X-Blue-Swallow-Operator-Token': session\.token/);
+});
+
+test('operator design system uses protected material layers, not generic neon', () => {
+  assert.match(stylesCss, /--material-pearl:/);
+  assert.match(stylesCss, /--oxidized-patina:/);
+  assert.match(stylesCss, /--bruised-violet:/);
+  assert.match(stylesCss, /--street-ink:/);
+  assert.match(stylesCss, /--corpo-paper:/);
+  assert.match(nacreStylesCss, /\.moire-field/);
+  assert.match(nacreStylesCss, /Street-built competence under executive restraint/);
+  assert.match(operatorShellApiJs, /NACRE_STYLE_PATH/);
+  assert.match(operatorShellApiJs, /NACRE_MARK_PATH/);
+  assert.doesNotMatch(`${stylesCss}\n${nacreStylesCss}`, /--neon-|same cyberpunk shell/i);
+  assert.doesNotMatch(`${stylesCss}\n${nacreStylesCss}`, /#72ff9f|#55e8ff|#ff4fd8|rgba\(71,\s*227,\s*130/i);
+});
+
+test('Nacre-Moiré interference mark is a committed accessible vector asset', () => {
+  assert.equal(existsSync(nacreMarkUrl), true);
+  const nacreMark = readFileSync(nacreMarkUrl, 'utf8');
+  assert.match(nacreMark, /<svg/);
+  assert.match(nacreMark, /<title(?:\s+[^>]*)?>Nacre-Moiré interference mark<\/title>/);
+  assert.match(nacreMark, /id="nacre-iridescence"/);
+  assert.match(nacreMark, /class="moire-line"/);
 });
 
 test('tzeentch shell exposes Mosaic before Murmurs and Positions after Actionable Intel', () => {


### PR DESCRIPTION
## Summary
- establish Nacre-Moiré as the authenticated operator identity with they/them reference language
- replace generic neon styling with a protected streetrat-turned-corpo material layer and interference mark
- keep anonymous `/operator`, `/agent`, static assets, and browser titles identity-free
- compose private shell/Interface Lab CSS and SVG only after passcode-issued operator-token validation

## Verification
- `node --test tests/*.test.mjs` — 128/128 pass
- `git diff --check`
- `graphify update .`
- Chromium renders: 390x844, 768x1024, 1440x1000
- static `app/` identity scan: zero Nacre/Moiré markers
- two independent code reviews; final review found no blocker