### PR TITLE
fix: tolerate SWA proxy auth collisions

### DIFF
--- a/api/_lib/operator-auth.js
+++ b/api/_lib/operator-auth.js
@@ -124,7 +124,7 @@ function verifyOperatorRequest(req, { now = Date.now() } = {}) {
     return { ok: false, status: 403, error: 'Operator session expired.' };
   }
 
-  return { ok: true, token: payload };
+  return { ok: true, token: payload, rawToken: token };
 }
 
 function extractBearerToken(req) {

--- a/api/_lib/operator-auth.js
+++ b/api/_lib/operator-auth.js
@@ -89,8 +89,8 @@ function requireOperatorToken(context, req) {
 }
 
 function verifyOperatorRequest(req, { now = Date.now() } = {}) {
-  const token = extractBearerToken(req);
-  if (!token) {
+  const tokens = extractOperatorTokens(req);
+  if (tokens.length === 0) {
     return { ok: false, status: 403, error: 'Operator session required.' };
   }
 
@@ -99,6 +99,19 @@ function verifyOperatorRequest(req, { now = Date.now() } = {}) {
     return { ok: false, status: 503, error: 'Operator token signing is not configured.' };
   }
 
+  let failure;
+  for (const token of tokens) {
+    const result = verifyOperatorToken(token, signingKey, now);
+    if (result.ok) {
+      return result;
+    }
+    failure ||= result;
+  }
+
+  return failure;
+}
+
+function verifyOperatorToken(token, signingKey, now) {
   const [encodedPayload, signature, extra] = String(token).split('.');
   if (!encodedPayload || !signature || extra !== undefined) {
     return { ok: false, status: 403, error: 'Invalid operator session token.' };
@@ -127,19 +140,12 @@ function verifyOperatorRequest(req, { now = Date.now() } = {}) {
   return { ok: true, token: payload, rawToken: token };
 }
 
-function extractBearerToken(req) {
+function extractOperatorTokens(req) {
   const explicitOperatorToken = toHeader(req, 'x-blue-swallow-operator-token').trim();
-  if (explicitOperatorToken) {
-    return explicitOperatorToken;
-  }
-
+  const cookieToken = extractCookieValue(toHeader(req, 'cookie'), OPERATOR_SESSION_COOKIE);
   const authorization = toHeader(req, 'authorization');
-  const match = authorization.match(/^Bearer\s+(.+)$/i);
-  if (match) {
-    return match[1].trim();
-  }
-
-  return extractCookieValue(toHeader(req, 'cookie'), OPERATOR_SESSION_COOKIE);
+  const authorizationToken = authorization.match(/^Bearer\s+(.+)$/i)?.[1]?.trim() || '';
+  return [...new Set([explicitOperatorToken, cookieToken, authorizationToken].filter(Boolean))];
 }
 
 function buildOperatorSessionCookie(session) {

--- a/api/operator-downloads/index.js
+++ b/api/operator-downloads/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { requireOperatorToken } = require('../_lib/operator-auth');
+const { buildOperatorSessionCookie, requireOperatorToken } = require('../_lib/operator-auth');
 const { createReleaseStore, toOperatorMetadata } = require('../_lib/wardriver-release-store');
 
 async function handler(context, req) {
@@ -18,7 +18,7 @@ async function handler(context, req) {
     return;
   }
 
-  return handleAuthorized(context, req, dependencies);
+  return handleAuthorized(context, req, dependencies, auth);
 }
 
 async function handle(context, req, dependencies) {
@@ -27,10 +27,10 @@ async function handle(context, req, dependencies) {
     return;
   }
 
-  return handleAuthorized(context, req, dependencies);
+  return handleAuthorized(context, req, dependencies, auth);
 }
 
-async function handleAuthorized(context, req, dependencies) {
+async function handleAuthorized(context, req, dependencies, auth) {
   const artifact = normalizeArtifact(req.params?.artifact);
   if (artifact !== 'metadata' && artifact !== 'apk') {
     context.res = jsonResponse(404, { ok: false, error: 'Unknown operator download artifact.' });
@@ -47,7 +47,7 @@ async function handleAuthorized(context, req, dependencies) {
   }
 
   if (artifact === 'metadata') {
-    context.res = metadataResponse(req, release);
+    context.res = metadataResponse(req, release, auth);
     return;
   }
 
@@ -74,19 +74,28 @@ function normalizeArtifact(value) {
   return String(value || '').trim().toLowerCase();
 }
 
-function metadataResponse(req, release) {
+function metadataResponse(req, release, auth) {
+  const sessionCookie = refreshOperatorSessionCookie(auth);
   return {
     status: 200,
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
       'Cache-Control': 'private, no-store',
       'X-Content-Type-Options': 'nosniff',
+      ...(sessionCookie ? { 'Set-Cookie': sessionCookie } : {}),
     },
     body: req.method === 'HEAD' ? undefined : {
       ok: true,
       artifact: toOperatorMetadata(release),
     },
   };
+}
+
+function refreshOperatorSessionCookie(auth) {
+  const token = typeof auth?.rawToken === 'string' ? auth.rawToken : '';
+  const expiresAt = Number(auth?.token?.exp);
+  const ttlSeconds = Number.isFinite(expiresAt) ? expiresAt - Math.floor(Date.now() / 1000) : 0;
+  return token && ttlSeconds > 0 ? buildOperatorSessionCookie({ token, ttlSeconds }) : '';
 }
 
 function isHttpsBlobUrl(value) {

--- a/specs/007-wardriver-immutable-release-delivery/plan.md
+++ b/specs/007-wardriver-immutable-release-delivery/plan.md
@@ -22,6 +22,7 @@ Replace the Functions-bundled debug APK with a private Azure Blob release accoun
 | Dedicated private release account | Limits runtime storage credentials to APK/manifest material only. |
 | No Functions fallback | Prevents stale binary resurrection. Missing/malformed manifest is an explicit 503. |
 | Blob redirect after operator authentication | Keeps BSS gate while avoiding Functions APK memory/bundle limits. |
+| Credential candidate verification | Prefer the explicit BSS header, then signed `HttpOnly` session cookie, then conventional bearer; verify each candidate so a stale cookie or SWA-injected bearer cannot eclipse a valid operator credential. |
 | OIDC uploader, no storage key in CI | Upload authority is short-lived and role-scoped. |
 | New release certificate | Default Android debug key is publicly reproducible and cannot sign a trusted release. |
 | Metadata-only device route | App can report freshness without gaining an artifact URL or operator credential. |

--- a/specs/007-wardriver-immutable-release-delivery/tasks.md
+++ b/specs/007-wardriver-immutable-release-delivery/tasks.md
@@ -30,3 +30,4 @@
 - [ ] T017 Provision the dedicated release account and least-privilege Wardriver publisher OIDC identity; configure the corresponding GitHub secrets and SWA runtime settings; trace TST-008.
 - [ ] T018 Generate/secure a new release keystore, produce the first tag, retain manifest/blob/run evidence, and complete the first device uninstall/reinstall migration; trace TST-008.
 - [ ] T019 Run `graphify update .` in both repositories, inspect scoped diffs for secrets/unrelated changes, and append verified evidence to the daily log.
+- [x] T020 [US1] Add a proxy-auth collision regression in `tests/operator-downloads-api.test.mjs`, then verify `api/_lib/operator-auth.js` accepts a valid signed cookie when SWA injects an unrelated `Authorization` bearer; trace TST-001.

--- a/specs/007-wardriver-immutable-release-delivery/tests.md
+++ b/specs/007-wardriver-immutable-release-delivery/tests.md
@@ -4,7 +4,7 @@
 
 | Test | Level | Covers | Procedure | Expected result | Planned path |
 |---|---|---|---|---|---|
-| TST-001 | Node unit | FR-002–FR-005, NFR-001/004 | Invoke protected routes with injected store and valid/invalid credentials. | Anonymous requests reject; valid metadata is private/no-store; APK is a bounded HTTPS read redirect, not bytes. | `tests/operator-downloads-api.test.mjs` |
+| TST-001 | Node unit | FR-002–FR-005, NFR-001/004 | Invoke protected routes with injected store and anonymous, conventional bearer, explicit BSS header, signed cookie, and invalid proxy-injected bearer combinations. | Anonymous requests reject; a valid operator credential survives a stale or SWA-injected competing credential; valid metadata is private/no-store; APK is a bounded HTTPS read redirect, not bytes. | `tests/operator-downloads-api.test.mjs` |
 | TST-002 | Node unit | FR-002–FR-004 | Feed malformed manifest/config and invalid blob path cases to the release store. | Explicit unavailable/config error; no legacy file read or arbitrary SAS. | `tests/operator-downloads-api.test.mjs` |
 | TST-003 | Node unit | FR-006, FR-010 | Invoke metadata-only route with a release-store double. | Only version/name/published notes; no blob/source/checksum/signer/download path. | `tests/wardriver-release-current-api.test.mjs` |
 | TST-004 | static/API shell | FR-007, NFR-003 | Inspect operator shell/script. | No hard-coded release version/hash/debug build or static APK filename; authenticated metadata drives facts. | `tests/operator-shell-download.test.mjs` |

--- a/tests/operator-downloads-api.test.mjs
+++ b/tests/operator-downloads-api.test.mjs
@@ -169,6 +169,21 @@ test('verified metadata refreshes the navigation cookie from a bearer session', 
   });
 });
 
+test('APK navigation honors a valid operator cookie over an injected platform bearer', async () => {
+  await withSigningKey(async () => {
+    const session = createOperatorToken();
+    const response = await invoke('apk', {
+      headers: {
+        authorization: 'Bearer static-web-apps-platform-token',
+        cookie: `bss_operator_session=${encodeURIComponent(session.token)}`,
+      },
+      dependencies: fakeReleaseStore(),
+    });
+
+    assert.equal(response.status, 302);
+  });
+});
+
 test('release storage failures produce an explicit unavailable response and no stale fallback', async () => {
   await withSigningKey(async () => {
     const session = createOperatorToken();

--- a/tests/operator-downloads-api.test.mjs
+++ b/tests/operator-downloads-api.test.mjs
@@ -146,6 +146,29 @@ test('operator APK request issues a bounded HTTPS redirect without buffering APK
   });
 });
 
+test('verified metadata refreshes the navigation cookie from a bearer session', async () => {
+  await withSigningKey(async () => {
+    const session = createOperatorToken();
+    const metadata = await invoke('metadata', {
+      headers: {
+        authorization: `Bearer ${session.token}`,
+        cookie: 'bss_operator_session=stale.invalid',
+      },
+      dependencies: fakeReleaseStore(),
+    });
+
+    assert.equal(metadata.status, 200);
+    assert.match(metadata.headers['Set-Cookie'], new RegExp(`^bss_operator_session=${encodeURIComponent(session.token)};`));
+
+    const navigationCookie = metadata.headers['Set-Cookie'].split(';', 1)[0];
+    const download = await invoke('apk', {
+      headers: { cookie: navigationCookie },
+      dependencies: fakeReleaseStore(),
+    });
+    assert.equal(download.status, 302);
+  });
+});
+
 test('release storage failures produce an explicit unavailable response and no stale fallback', async () => {
   await withSigningKey(async () => {
     const session = createOperatorToken();


### PR DESCRIPTION
## Root cause
Azure Static Web Apps can inject an unrelated `Authorization` bearer into browser navigations. The APK anchor relied on the signed HttpOnly cookie, but the runtime selected the injected bearer first and returned 403.

## Change
- validate explicit BSS header, signed cookie, and conventional bearer candidates in that order
- accept the first valid signed operator token
- add a regression for valid cookie plus injected platform bearer

## Verification
- `node --test tests/*.test.mjs` — 139 passed
- `graphify update .` — 2,643 nodes / 4,641 edges