### PR TITLE
fix(wardriver): use policy-compliant static basemap host

### DIFF
--- a/.github/workflows/publish-wardriver-basemap.yml
+++ b/.github/workflows/publish-wardriver-basemap.yml
@@ -22,8 +22,9 @@ concurrency:
 env:
   RESOURCE_GROUP: rg-blue-swallow
   PLANETILER_VERSION: v0.10.2
-  # The published endpoint is https://<account>.blob.core.windows.net/wardriver-basemap/v1/style.json.
-  STYLE_BLOB_PATH: v1/style.json
+  # The policy blocks ordinary anonymous Blob access. The named $web static-website path is public read-only.
+  PUBLIC_PREFIX: wardriver-basemap
+  STYLE_OBJECT_PATH: v1/style.json
 
 jobs:
   publish:
@@ -57,15 +58,17 @@ jobs:
           account=$(jq -r '.wardriverReleaseStorageAccountName.value' <<<"$outputs")
           container=$(jq -r '.wardriverBasemapContainerName.value' <<<"$outputs")
           style_url=$(jq -r '.wardriverBasemapStyleUrl.value' <<<"$outputs")
-          expected_style_url="https://${account}.blob.core.windows.net/${container}/${STYLE_BLOB_PATH}"
-          if ! [[ "$account" =~ ^[a-z0-9]{3,24}$ ]] || [ "$container" != 'wardriver-basemap' ] || [ "$style_url" != "$expected_style_url" ]; then
-            echo '::error::Deployed Wardriver basemap outputs are absent or violate the public-style contract.'
+          expected_style_url_pattern="^https://${account}\.[a-z0-9-]+\.web\.core\.windows\.net/${PUBLIC_PREFIX}/${STYLE_OBJECT_PATH}$"
+          if ! [[ "$account" =~ ^[a-z0-9]{3,24}$ ]] || [ "$container" != '$web' ] || ! [[ "$style_url" =~ $expected_style_url_pattern ]]; then
+            echo '::error::Deployed Wardriver basemap outputs are absent or violate the static-website public-style contract.'
             exit 1
           fi
+          public_root="${style_url%/${STYLE_OBJECT_PATH}}"
           echo 'This workflow requires Storage Blob Data Contributor on the Wardriver storage account only.'
           echo "account=$account" >> "$GITHUB_OUTPUT"
           echo "container=$container" >> "$GITHUB_OUTPUT"
           echo "style_url=$style_url" >> "$GITHUB_OUTPUT"
+          echo "public_root=$public_root" >> "$GITHUB_OUTPUT"
 
       - name: Verify OIDC Blob data-plane access
         env:
@@ -122,16 +125,15 @@ jobs:
         id: render
         env:
           WORK: ${{ steps.inputs.outputs.work }}
-          ACCOUNT: ${{ steps.basemap.outputs.account }}
-          CONTAINER: ${{ steps.basemap.outputs.container }}
+          PUBLIC_ROOT: ${{ steps.basemap.outputs.public_root }}
           SOURCE_URL: ${{ steps.inputs.outputs.source_url }}
           SOURCE_SHA256: ${{ steps.inputs.outputs.source_sha256 }}
           PLANETILER_SHA256: ${{ steps.inputs.outputs.planetiler_sha256 }}
           TILE_COUNT: ${{ steps.tiles.outputs.tile_count }}
         run: |
           set -euo pipefail
-          generation="v1/generations/${SOURCE_SHA256:0:16}-${PLANETILER_SHA256:0:16}-${GITHUB_SHA:0:12}"
-          public_root="https://${ACCOUNT}.blob.core.windows.net/${CONTAINER}"
+          generation="${PUBLIC_PREFIX}/v1/generations/${SOURCE_SHA256:0:16}-${PLANETILER_SHA256:0:16}-${GITHUB_SHA:0:12}"
+          public_root="$PUBLIC_ROOT"
           tile_base_url="${public_root}/${generation}/tiles"
           python3 scripts/render-wardriver-basemap-style.py \
             --template basemap/style.template.json \
@@ -203,7 +205,7 @@ jobs:
           az storage blob upload --auth-mode login \
             --account-name "$ACCOUNT" \
             --container-name "$CONTAINER" \
-            --name "$STYLE_BLOB_PATH" \
+            --name "$PUBLIC_PREFIX/$STYLE_OBJECT_PATH" \
             --file "$WORK/style.json" \
             --overwrite true \
             --content-type application/json \
@@ -212,7 +214,7 @@ jobs:
           az storage blob upload --auth-mode login \
             --account-name "$ACCOUNT" \
             --container-name "$CONTAINER" \
-            --name v1/basemap-provenance.json \
+            --name "$PUBLIC_PREFIX/v1/basemap-provenance.json" \
             --file "$WORK/basemap-provenance.json" \
             --overwrite true \
             --content-type application/json \

--- a/infra/modules/wardriver-release-storage.bicep
+++ b/infra/modules/wardriver-release-storage.bicep
@@ -7,8 +7,8 @@ param location string
 @description('Private Blob container containing immutable Wardriver APKs and manifests.')
 param containerName string = 'wardriver-releases'
 
-@description('Public Blob container containing only the BSS-hosted Wardriver basemap style and vector tiles.')
-param basemapContainerName string = 'wardriver-basemap'
+@description('The system $web container. It exposes only static website paths; ordinary Blob containers remain private.')
+param basemapContainerName string = '$web'
 
 var storageAccountName = toLower('bsswd${uniqueString(subscription().id, resourceGroup().id, prefix)}')
 
@@ -21,9 +21,9 @@ resource releaseStorage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   }
   properties: {
     accessTier: 'Hot'
-    // The release container stays private. This account also has one blob-read-only basemap
-    // container so MapLibre can request public style and tile bytes without a client secret.
-    allowBlobPublicAccess: true
+    // Azure Policy forbids ordinary anonymous Blob access. $web remains the one public,
+    // read-only static-website surface; every normal Blob container stays private.
+    allowBlobPublicAccess: false
     allowCrossTenantReplication: false
     allowSharedKeyAccess: true
     defaultToOAuthAuthentication: true
@@ -77,6 +77,17 @@ resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01'
   }
 }
 
+// Microsoft documents $web as anonymously readable even when ordinary Blob anonymous
+// access is disabled. It is the only public delivery surface in this account.
+resource basemapStaticWebsite 'Microsoft.Storage/storageAccounts/staticWebsite@2023-05-01' = {
+  parent: releaseStorage
+  name: 'default'
+  properties: {
+    indexDocument: 'index.html'
+    error404Document: '404.html'
+  }
+}
+
 resource releaseContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
   parent: blobService
   name: containerName
@@ -85,16 +96,9 @@ resource releaseContainer 'Microsoft.Storage/storageAccounts/blobServices/contai
   }
 }
 
-// `Blob` permits anonymous reads of named style/tile objects but not container listing.
-resource wardriverBasemapContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
-  parent: blobService
-  name: basemapContainerName
-  properties: {
-    publicAccess: 'Blob'
-  }
-}
+// `$web` is created by the staticWebsite setting. Do not declare it with Blob public access.
 
 output storageAccountName string = releaseStorage.name
 output releaseContainerName string = releaseContainer.name
-output basemapContainerName string = wardriverBasemapContainer.name
-output wardriverBasemapStyleUrl string = 'https://${releaseStorage.name}.blob.${environment().suffixes.storage}/${wardriverBasemapContainer.name}/v1/style.json'
+output basemapContainerName string = basemapContainerName
+output wardriverBasemapStyleUrl string = '${releaseStorage.properties.primaryEndpoints.web}wardriver-basemap/v1/style.json'

--- a/specs/009-wardriver-maplibre-basemap/plan.md
+++ b/specs/009-wardriver-maplibre-basemap/plan.md
@@ -2,10 +2,10 @@
 
 ## Implementation approach
 
-1. Extend the existing dedicated Wardriver Blob account with a second container, `wardriver-basemap`. Keep the release container private; allow only named Blob reads for basemap content.
-2. Produce a MapLibre v8 style from `basemap/style.template.json`. The checked-in template has no remote tile origin. Publication renders a generation-specific BSS Blob tile base into the style.
-3. On protected manual dispatch, prove the OIDC principal can read the scoped basemap container before any expensive work; then download the bounded Washington Geofabrik PBF and its checksum, download Planetiler `v0.10.2` and its checksum, render vector MBTiles on Java 21, extract gzip XYZ PBF objects, and publish provenance plus immutable tiles.
-4. Compile signed Wardriver `bss.15+` with `WIGLE_BSS_FORCE_MAPLIBRE=true` and the BSS Blob style endpoint. Ignore old renderer/style preferences on all MapLibre surfaces.
+1. Keep the dedicated Wardriver Blob account's ordinary anonymous access disabled. Keep the release container private; enable its `$web` static-website resource as the sole public read-only basemap path.
+2. Produce a MapLibre v8 style from `basemap/style.template.json`. The checked-in template has no remote tile origin. Publication renders a generation-specific BSS static-website tile base into the style.
+3. On protected manual dispatch, prove the OIDC principal can read `$web` before any expensive work; then download the bounded Washington Geofabrik PBF and its checksum, download Planetiler `v0.10.2` and its checksum, render vector MBTiles on Java 21, extract gzip XYZ PBF objects, and publish provenance plus immutable tiles.
+4. Compile signed Wardriver `bss.15+` with `WIGLE_BSS_FORCE_MAPLIBRE=true` and the BSS static-website style endpoint. Ignore old renderer/style preferences on all MapLibre surfaces.
 5. Deploy the BSS infrastructure and publish the first source generation before creating a device candidate. Do not publish an APK or mutable release manifest before physical acceptance.
 
 ## Storage and cache contract
@@ -13,10 +13,10 @@
 | Object | Access | Mutability | Cache |
 |---|---|---|---|
 | `wardriver-releases/*` | authenticated/SAS | immutable release objects | existing release policy |
-| `wardriver-basemap/v1/generations/<id>/tiles/*` | public named Blob | immutable | `public, max-age=31536000, immutable` |
-| `wardriver-basemap/v1/generations/<id>/basemap-provenance.json` | public named Blob | immutable | `public, max-age=31536000, immutable` |
-| `wardriver-basemap/v1/style.json` | public named Blob | versioned current pointer | `no-store` |
-| `wardriver-basemap/v1/basemap-provenance.json` | public named Blob | versioned current pointer | `no-store` |
+| `$web/wardriver-basemap/v1/generations/<id>/tiles/*` | public named static-website object | immutable | `public, max-age=31536000, immutable` |
+| `$web/wardriver-basemap/v1/generations/<id>/basemap-provenance.json` | public named static-website object | immutable | `public, max-age=31536000, immutable` |
+| `$web/wardriver-basemap/v1/style.json` | public named static-website object | versioned current pointer | `no-store` |
+| `$web/wardriver-basemap/v1/basemap-provenance.json` | public named static-website object | versioned current pointer | `no-store` |
 
 No Function handles a tile request. This prevents application-level location logging and a hot tile proxy. Azure platform access behavior remains subject to the deployed platform account policy.
 

--- a/specs/009-wardriver-maplibre-basemap/spec.md
+++ b/specs/009-wardriver-maplibre-basemap/spec.md
@@ -10,28 +10,28 @@ This specification owns observable basemap behavior for Wardriver `bss.15+`.
 
 - `bss.14` is immutable. This work does not alter its renderer, APK, tag, or release manifest.
 - A signed `bss.15+` release uses MapLibre. A persisted Google/FOSS preference must not select a different renderer or style.
-- The basemap is served from Blue Swallow Azure Blob Storage. The Android client contains no Maps credential and no tile-provider credential.
+- The basemap is served from the Azure Storage static-website endpoint (`$web`) in the Blue Swallow release account. Ordinary Blob containers remain private. The Android client contains no Maps credential and no tile-provider credential.
 - The initial approved source package is the Geofabrik Washington OpenStreetMap extract. Its published provenance identifies the exact source hash, Planetiler hash, source commit, tile generation, and style hash.
 
 ## Requirements
 
-### R1 — Public named basemap objects; private APK objects
+### R1 — Public static-website paths; private Blob containers
 
-The existing Wardriver storage account shall expose one `wardriver-basemap` container with Blob-level public read access. It shall not permit anonymous container listing. The existing `wardriver-releases` container shall remain `publicAccess: 'None'`.
+The existing Wardriver storage account shall set `allowBlobPublicAccess: false`. The existing `wardriver-releases` container shall remain `publicAccess: 'None'`. Basemap bytes shall be uploaded under the Storage static website's system `$web` container and read only through explicit static-website object paths; ordinary Blob listing remains unauthenticated-denied.
 
 ### R2 — Client style endpoint
 
 The BSS deployment shall output a style endpoint of this form:
 
 ```text
-https://<storage-account>.blob.core.windows.net/wardriver-basemap/v1/style.json
+https://<storage-account>.<azure-web-zone>.web.core.windows.net/wardriver-basemap/v1/style.json
 ```
 
-The style shall reference only versioned BSS Blob tile URLs. It shall contain OpenStreetMap attribution, no client credential, and no third-party runtime tile origin.
+The style shall reference only versioned BSS static-website tile URLs. It shall contain OpenStreetMap attribution, no client credential, and no third-party runtime tile origin.
 
 ### R3 — Immutable tiles, mutable style pointer
 
-A tile generation shall use a source/renderer/commit-derived prefix. Tiles and generation provenance are immutable and cacheable for one year. `v1/style.json` and `v1/basemap-provenance.json` are versioned Blob pointers with `Cache-Control: no-store`.
+A tile generation shall use a source/renderer/commit-derived prefix below `$web/wardriver-basemap`. Tiles and generation provenance are immutable and cacheable for one year. `wardriver-basemap/v1/style.json` and `wardriver-basemap/v1/basemap-provenance.json` are mutable static-website pointers with `Cache-Control: no-store`.
 
 ### R4 — Source and publication controls
 
@@ -47,7 +47,7 @@ When the BSS style or tile service is unavailable, the app shall retain existing
 
 ## Acceptance evidence
 
-1. Bicep validation proves the public Blob-only basemap container and private release container.
+1. Bicep validation proves ordinary Blob access is disabled, the release container is private, and only the Storage static-website `$web` surface is configured for basemap objects.
 2. The manual workflow verifies source/toolchain checksums, emits provenance, uploads named objects through OIDC, and reads a public style plus sample tile without listing.
 3. The Android release contract proves `bss.15+` MapLibre selection without a Maps secret.
 4. A physical device receipt is required before tag/promotion.

--- a/specs/009-wardriver-maplibre-basemap/tasks.md
+++ b/specs/009-wardriver-maplibre-basemap/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Wardriver MapLibre Basemap
 
-- [x] Add public named-object BSS basemap storage contract while preserving private release objects.
+- [x] Replace the policy-blocked public Blob container design with a `$web` static-website basemap path while preserving private release objects.
 - [x] Add BSS style template, immutable vector-tile extractor, style renderer, and provenance-capable publisher workflow.
 - [x] Check Bicep locally; run a Java 21 Planetiler canary and local static tests.
 - [ ] Deploy infrastructure to Azure and run the protected first Washington publication.

--- a/specs/009-wardriver-maplibre-basemap/tests.md
+++ b/specs/009-wardriver-maplibre-basemap/tests.md
@@ -2,8 +2,8 @@
 
 | Requirement | Test / evidence | Status |
 |---|---|---|
-| R1 | `tests/wardriver-basemap-delivery-config.test.mjs`; `az bicep build infra/main.bicep` | implemented locally |
-| R2 | Style-template static contract; render-script canary with BSS Blob URL | implemented locally |
+| R1 | `tests/wardriver-basemap-delivery-config.test.mjs`; `az bicep build infra/main.bicep`; static-website `$web` configuration with ordinary Blob access disabled | implemented locally |
+| R2 | Style-template static contract; render-script canary with BSS static-website URL | implemented locally |
 | R3 | Publication workflow static contract checks versioned generation path, cache headers, provenance output | implemented locally |
 | R4 | Workflow static contract checks manual dispatch, OIDC data-plane preflight before source download, checksum verification, Java 21 | implemented locally |
 | R5 | Wardriver `MapLibreReleaseContractTest` and `ReleasePromotionContractTest` | implemented locally; candidate build pending |
@@ -11,4 +11,4 @@
 
 ## Local canary
 
-Planetiler `v0.10.2` was checksum-verified and run against its Monaco download fixture with Java 21. The extractor emitted 246 gzip PBF tiles across zoom 0–14 and confirmed `water` and `transportation` source layers. The rendered style referenced only the supplied BSS Blob URL.
+Planetiler `v0.10.2` was checksum-verified and run against its Monaco download fixture with Java 21. The extractor emitted 246 gzip PBF tiles across zoom 0–14 and confirmed `water` and `transportation` source layers. The rendered style referenced only the supplied BSS static-website URL.

--- a/tests/wardriver-basemap-delivery-config.test.mjs
+++ b/tests/wardriver-basemap-delivery-config.test.mjs
@@ -12,15 +12,18 @@ function parseJson(path) {
   return JSON.parse(read(path));
 }
 
-test('Bicep separates public BSS basemap blobs from the private immutable release container', () => {
+test('Bicep keeps release blobs private and serves basemap objects only from the storage static-website endpoint', () => {
   assert.equal(existsSync(storageModule), true);
   const storage = read('infra/modules/wardriver-release-storage.bicep');
   const main = read('infra/main.bicep');
 
-  assert.match(storage, /allowBlobPublicAccess:\s*true/);
+  assert.match(storage, /allowBlobPublicAccess:\s*false/);
+  assert.match(storage, /resource basemapStaticWebsite 'Microsoft\.Storage\/storageAccounts\/staticWebsite@2023-05-01'/);
+  assert.match(storage, /indexDocument: 'index\.html'/);
   assert.match(storage, /resource releaseContainer[\s\S]*?publicAccess:\s*'None'/);
-  assert.match(storage, /resource wardriverBasemapContainer[\s\S]*?publicAccess:\s*'Blob'/);
-  assert.match(storage, /corsRules/);
+  assert.doesNotMatch(storage, /publicAccess:\s*'Blob'/);
+  assert.match(storage, /basemapContainerName string = '\$web'/);
+  assert.match(storage, /primaryEndpoints\.web/);
   assert.match(storage, /wardriverBasemapStyleUrl/);
   assert.match(main, /wardriverBasemapStyleUrl/);
 });
@@ -56,11 +59,14 @@ test('manual basemap publication verifies its source and toolchain, emits proven
   assert.match(workflow, /Storage Blob Data Contributor/);
   assert.match(workflow, /Verify OIDC Blob data-plane access/);
   assert.match(workflow, /az storage container show --auth-mode login/);
+  assert.ok(workflow.includes('web\\.core\\.windows\\.net'));
+  assert.match(workflow, /PUBLIC_PREFIX: wardriver-basemap/);
+  assert.match(workflow, /container" != '\$web'/);
   assert.ok(
     workflow.indexOf('Verify OIDC Blob data-plane access') < workflow.indexOf('Fetch and verify bounded OpenStreetMap input'),
     'data-plane RBAC must fail before the expensive map build',
   );
-  assert.match(workflow, /wardriver-basemap\/v1\/style\.json/);
+  assert.match(workflow, /STYLE_OBJECT_PATH: v1\/style\.json/);
   assert.match(workflow, /basemap-provenance\.json/);
   assert.match(workflow, /content-cache-control 'public, max-age=31536000, immutable'/);
   assert.doesNotMatch(workflow, /--account-key/);

--- a/tests/wardriver-release-delivery-config.test.mjs
+++ b/tests/wardriver-release-delivery-config.test.mjs
@@ -7,12 +7,13 @@ const main = readFileSync(new URL('infra/main.bicep', root), 'utf8');
 const workflow = readFileSync(new URL('.github/workflows/deploy-static-web-app.yml', root), 'utf8');
 const moduleUrl = new URL('infra/modules/wardriver-release-storage.bicep', root);
 
-test('Bicep provisions a recoverable Wardriver release account whose release container remains private', () => {
+test('Bicep provisions a recoverable Wardriver release account with private ordinary Blob access', () => {
   assert.equal(existsSync(moduleUrl), true);
   const storage = readFileSync(moduleUrl, 'utf8');
   assert.match(main, /wardriver-release-storage/);
   assert.match(storage, /Microsoft\.Storage\/storageAccounts/);
-  assert.match(storage, /allowBlobPublicAccess:\s*true/);
+  assert.match(storage, /allowBlobPublicAccess:\s*false/);
+  assert.match(storage, /resource basemapStaticWebsite 'Microsoft\.Storage\/storageAccounts\/staticWebsite@2023-05-01'/);
   assert.match(storage, /minimumTlsVersion:\s*'TLS1_2'/);
   assert.match(storage, /isVersioningEnabled:\s*true/);
   assert.match(storage, /deleteRetentionPolicy/);


### PR DESCRIPTION
## Root cause
Azure policy rejected the ordinary anonymous Blob container: `PublicAccessNotPermitted`.

## Repair
- keeps `allowBlobPublicAccess: false` and `wardriver-releases` private
- publishes MapLibre objects under the Azure Storage `$web` static-website surface, which Microsoft documents as anonymously readable even with ordinary Blob anonymous access disabled
- preserves OIDC publication, immutable generations, provenance, and early data-plane RBAC preflight

## Verification
- `node --test tests/*.test.mjs` — 168 passed
- `az bicep build --file infra/main.bicep`
- Python workflow YAML parse and `git diff --check`

The Bicep compiler emits BCP081 for the Azure `staticWebsite` resource schema, but compilation succeeds; the next protected Azure deployment is the live validation gate.