### PR TITLE
fix(wardriver): enable static host after OIDC proof

### DIFF
--- a/.github/workflows/publish-wardriver-basemap.yml
+++ b/.github/workflows/publish-wardriver-basemap.yml
@@ -46,7 +46,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Resolve the deployed public basemap contract
+      - name: Resolve the deployed basemap storage target
         id: basemap
         run: |
           set -euo pipefail
@@ -57,18 +57,13 @@ jobs:
             -o json)
           account=$(jq -r '.wardriverReleaseStorageAccountName.value' <<<"$outputs")
           container=$(jq -r '.wardriverBasemapContainerName.value' <<<"$outputs")
-          style_url=$(jq -r '.wardriverBasemapStyleUrl.value' <<<"$outputs")
-          expected_style_url_pattern="^https://${account}\.[a-z0-9-]+\.web\.core\.windows\.net/${PUBLIC_PREFIX}/${STYLE_OBJECT_PATH}$"
-          if ! [[ "$account" =~ ^[a-z0-9]{3,24}$ ]] || [ "$container" != '$web' ] || ! [[ "$style_url" =~ $expected_style_url_pattern ]]; then
-            echo '::error::Deployed Wardriver basemap outputs are absent or violate the static-website public-style contract.'
+          if ! [[ "$account" =~ ^[a-z0-9]{3,24}$ ]] || [ "$container" != '$web' ]; then
+            echo '::error::Deployed Wardriver basemap storage outputs are absent or violate the private-Blob contract.'
             exit 1
           fi
-          public_root="${style_url%/${STYLE_OBJECT_PATH}}"
           echo 'This workflow requires Storage Blob Data Contributor on the Wardriver storage account only.'
           echo "account=$account" >> "$GITHUB_OUTPUT"
           echo "container=$container" >> "$GITHUB_OUTPUT"
-          echo "style_url=$style_url" >> "$GITHUB_OUTPUT"
-          echo "public_root=$public_root" >> "$GITHUB_OUTPUT"
 
       - name: Verify OIDC Blob data-plane access
         env:
@@ -83,6 +78,36 @@ jobs:
             --account-name "$ACCOUNT" \
             --name "$CONTAINER" \
             --only-show-errors -o none
+
+      - name: Enable Storage static website
+        id: static_website
+        env:
+          ACCOUNT: ${{ steps.basemap.outputs.account }}
+        run: |
+          set -euo pipefail
+          # $web is the policy-compliant public path. This data-plane operation is deliberately
+          # after the scoped OIDC proof and before any costly input download.
+          az storage blob service-properties update --auth-mode login \
+            --account-name "$ACCOUNT" \
+            --static-website true \
+            --index-document index.html \
+            --404-document 404.html \
+            --only-show-errors -o none
+          static_website_root=$(az storage account show \
+            --resource-group "$RESOURCE_GROUP" \
+            --name "$ACCOUNT" \
+            --query 'primaryEndpoints.web' \
+            -o tsv)
+          static_website_root="${static_website_root%/}/"
+          style_url="${static_website_root}${PUBLIC_PREFIX}/${STYLE_OBJECT_PATH}"
+          expected_style_url_pattern="^https://${ACCOUNT}\\.[a-z0-9-]+\\.web\\.core\\.windows\\.net/${PUBLIC_PREFIX}/${STYLE_OBJECT_PATH}$"
+          if ! [[ "$style_url" =~ $expected_style_url_pattern ]]; then
+            echo '::error::Storage static-website endpoint is absent or violates the BSS style contract.'
+            exit 1
+          fi
+          public_root="${style_url%/${STYLE_OBJECT_PATH}}"
+          echo "style_url=$style_url" >> "$GITHUB_OUTPUT"
+          echo "public_root=$public_root" >> "$GITHUB_OUTPUT"
 
       - name: Fetch and verify bounded OpenStreetMap input and Planetiler
         id: inputs
@@ -125,7 +150,7 @@ jobs:
         id: render
         env:
           WORK: ${{ steps.inputs.outputs.work }}
-          PUBLIC_ROOT: ${{ steps.basemap.outputs.public_root }}
+          PUBLIC_ROOT: ${{ steps.static_website.outputs.public_root }}
           SOURCE_URL: ${{ steps.inputs.outputs.source_url }}
           SOURCE_SHA256: ${{ steps.inputs.outputs.source_sha256 }}
           PLANETILER_SHA256: ${{ steps.inputs.outputs.planetiler_sha256 }}
@@ -223,7 +248,7 @@ jobs:
 
       - name: Verify public named-object delivery without a Blob listing
         env:
-          STYLE_URL: ${{ steps.basemap.outputs.style_url }}
+          STYLE_URL: ${{ steps.static_website.outputs.style_url }}
           TILE_BASE_URL: ${{ steps.render.outputs.tile_base_url }}
           SAMPLE_TILE: ${{ steps.tiles.outputs.sample_tile }}
         run: |

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -198,7 +198,6 @@ output postgresGeoRedundantBackup string = postgresModule.outputs.geoRedundantBa
 output wardriverReleaseStorageAccountName string = wardriverReleaseStorage.outputs.storageAccountName
 output wardriverReleaseContainerName string = wardriverReleaseStorage.outputs.releaseContainerName
 output wardriverBasemapContainerName string = wardriverReleaseStorage.outputs.basemapContainerName
-output wardriverBasemapStyleUrl string = wardriverReleaseStorage.outputs.wardriverBasemapStyleUrl
 output postgresHighAvailabilityMode string = postgresModule.outputs.highAvailabilityMode
 output openAiDeployed bool = deployOpenAi
 output openAiEndpoint string = deployOpenAi ? openAiModule!.outputs.endpoint : ''

--- a/infra/modules/wardriver-release-storage.bicep
+++ b/infra/modules/wardriver-release-storage.bicep
@@ -77,17 +77,6 @@ resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01'
   }
 }
 
-// Microsoft documents $web as anonymously readable even when ordinary Blob anonymous
-// access is disabled. It is the only public delivery surface in this account.
-resource basemapStaticWebsite 'Microsoft.Storage/storageAccounts/staticWebsite@2023-05-01' = {
-  parent: releaseStorage
-  name: 'default'
-  properties: {
-    indexDocument: 'index.html'
-    error404Document: '404.html'
-  }
-}
-
 resource releaseContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
   parent: blobService
   name: containerName
@@ -96,9 +85,8 @@ resource releaseContainer 'Microsoft.Storage/storageAccounts/blobServices/contai
   }
 }
 
-// `$web` is created by the staticWebsite setting. Do not declare it with Blob public access.
+// `$web` is enabled only by the protected publisher after OIDC data-plane proof.
 
 output storageAccountName string = releaseStorage.name
 output releaseContainerName string = releaseContainer.name
 output basemapContainerName string = basemapContainerName
-output wardriverBasemapStyleUrl string = '${releaseStorage.properties.primaryEndpoints.web}wardriver-basemap/v1/style.json'

--- a/specs/009-wardriver-maplibre-basemap/plan.md
+++ b/specs/009-wardriver-maplibre-basemap/plan.md
@@ -2,7 +2,7 @@
 
 ## Implementation approach
 
-1. Keep the dedicated Wardriver Blob account's ordinary anonymous access disabled. Keep the release container private; enable its `$web` static-website resource as the sole public read-only basemap path.
+1. Keep the dedicated Wardriver Blob account's ordinary anonymous access disabled. Keep the release container private; during protected manual publication, prove OIDC data-plane access then enable its `$web` static-website resource as the sole public read-only basemap path.
 2. Produce a MapLibre v8 style from `basemap/style.template.json`. The checked-in template has no remote tile origin. Publication renders a generation-specific BSS static-website tile base into the style.
 3. On protected manual dispatch, prove the OIDC principal can read `$web` before any expensive work; then download the bounded Washington Geofabrik PBF and its checksum, download Planetiler `v0.10.2` and its checksum, render vector MBTiles on Java 21, extract gzip XYZ PBF objects, and publish provenance plus immutable tiles.
 4. Compile signed Wardriver `bss.15+` with `WIGLE_BSS_FORCE_MAPLIBRE=true` and the BSS static-website style endpoint. Ignore old renderer/style preferences on all MapLibre surfaces.

--- a/specs/009-wardriver-maplibre-basemap/spec.md
+++ b/specs/009-wardriver-maplibre-basemap/spec.md
@@ -17,11 +17,11 @@ This specification owns observable basemap behavior for Wardriver `bss.15+`.
 
 ### R1 — Public static-website paths; private Blob containers
 
-The existing Wardriver storage account shall set `allowBlobPublicAccess: false`. The existing `wardriver-releases` container shall remain `publicAccess: 'None'`. Basemap bytes shall be uploaded under the Storage static website's system `$web` container and read only through explicit static-website object paths; ordinary Blob listing remains unauthenticated-denied.
+The existing Wardriver storage account shall set `allowBlobPublicAccess: false`. The existing `wardriver-releases` container shall remain `publicAccess: 'None'`. The protected manual publisher shall enable the Storage static website and upload basemap bytes under its system `$web` container; clients read only through explicit static-website object paths, while ordinary Blob listing remains unauthenticated-denied.
 
 ### R2 — Client style endpoint
 
-The BSS deployment shall output a style endpoint of this form:
+After it enables `$web`, the protected publisher shall resolve and emit a style endpoint of this form:
 
 ```text
 https://<storage-account>.<azure-web-zone>.web.core.windows.net/wardriver-basemap/v1/style.json

--- a/specs/009-wardriver-maplibre-basemap/tests.md
+++ b/specs/009-wardriver-maplibre-basemap/tests.md
@@ -2,7 +2,7 @@
 
 | Requirement | Test / evidence | Status |
 |---|---|---|
-| R1 | `tests/wardriver-basemap-delivery-config.test.mjs`; `az bicep build infra/main.bicep`; static-website `$web` configuration with ordinary Blob access disabled | implemented locally |
+| R1 | `tests/wardriver-basemap-delivery-config.test.mjs`; `az bicep build infra/main.bicep`; ordinary Blob access disabled and manual OIDC-gated `$web` enablement | implemented locally |
 | R2 | Style-template static contract; render-script canary with BSS static-website URL | implemented locally |
 | R3 | Publication workflow static contract checks versioned generation path, cache headers, provenance output | implemented locally |
 | R4 | Workflow static contract checks manual dispatch, OIDC data-plane preflight before source download, checksum verification, Java 21 | implemented locally |

--- a/tests/wardriver-basemap-delivery-config.test.mjs
+++ b/tests/wardriver-basemap-delivery-config.test.mjs
@@ -12,20 +12,18 @@ function parseJson(path) {
   return JSON.parse(read(path));
 }
 
-test('Bicep keeps release blobs private and serves basemap objects only from the storage static-website endpoint', () => {
+test('Bicep keeps ordinary release blobs private and reserves $web for the manually gated basemap publication', () => {
   assert.equal(existsSync(storageModule), true);
   const storage = read('infra/modules/wardriver-release-storage.bicep');
   const main = read('infra/main.bicep');
 
   assert.match(storage, /allowBlobPublicAccess:\s*false/);
-  assert.match(storage, /resource basemapStaticWebsite 'Microsoft\.Storage\/storageAccounts\/staticWebsite@2023-05-01'/);
-  assert.match(storage, /indexDocument: 'index\.html'/);
+  assert.doesNotMatch(storage, /resource basemapStaticWebsite/);
   assert.match(storage, /resource releaseContainer[\s\S]*?publicAccess:\s*'None'/);
   assert.doesNotMatch(storage, /publicAccess:\s*'Blob'/);
   assert.match(storage, /basemapContainerName string = '\$web'/);
-  assert.match(storage, /primaryEndpoints\.web/);
-  assert.match(storage, /wardriverBasemapStyleUrl/);
-  assert.match(main, /wardriverBasemapStyleUrl/);
+  assert.doesNotMatch(storage, /wardriverBasemapStyleUrl/);
+  assert.doesNotMatch(main, /wardriverBasemapStyleUrl/);
 });
 
 test('the checked-in style is BSS-branded, attributable, and cannot point at a third-party tile origin', () => {
@@ -59,12 +57,20 @@ test('manual basemap publication verifies its source and toolchain, emits proven
   assert.match(workflow, /Storage Blob Data Contributor/);
   assert.match(workflow, /Verify OIDC Blob data-plane access/);
   assert.match(workflow, /az storage container show --auth-mode login/);
-  assert.ok(workflow.includes('web\\.core\\.windows\\.net'));
+  assert.match(workflow, /Enable Storage static website/);
+  assert.match(workflow, /az storage blob service-properties update --auth-mode login/);
+  assert.match(workflow, /--static-website true/);
+  assert.match(workflow, /expected_style_url_pattern/);
+  assert.match(workflow, /primaryEndpoints\.web/);
   assert.match(workflow, /PUBLIC_PREFIX: wardriver-basemap/);
   assert.match(workflow, /container" != '\$web'/);
   assert.ok(
     workflow.indexOf('Verify OIDC Blob data-plane access') < workflow.indexOf('Fetch and verify bounded OpenStreetMap input'),
     'data-plane RBAC must fail before the expensive map build',
+  );
+  assert.ok(
+    workflow.indexOf('Enable Storage static website') < workflow.indexOf('Fetch and verify bounded OpenStreetMap input'),
+    'the public static endpoint must be enabled only after OIDC proof and before tile generation',
   );
   assert.match(workflow, /STYLE_OBJECT_PATH: v1\/style\.json/);
   assert.match(workflow, /basemap-provenance\.json/);

--- a/tests/wardriver-release-delivery-config.test.mjs
+++ b/tests/wardriver-release-delivery-config.test.mjs
@@ -13,7 +13,7 @@ test('Bicep provisions a recoverable Wardriver release account with private ordi
   assert.match(main, /wardriver-release-storage/);
   assert.match(storage, /Microsoft\.Storage\/storageAccounts/);
   assert.match(storage, /allowBlobPublicAccess:\s*false/);
-  assert.match(storage, /resource basemapStaticWebsite 'Microsoft\.Storage\/storageAccounts\/staticWebsite@2023-05-01'/);
+  assert.doesNotMatch(storage, /resource basemapStaticWebsite/);
   assert.match(storage, /minimumTlsVersion:\s*'TLS1_2'/);
   assert.match(storage, /isVersioningEnabled:\s*true/);
   assert.match(storage, /deleteRetentionPolicy/);


### PR DESCRIPTION
## Root cause
PR #9 used the invalid ARM resource path `Microsoft.Storage/storageAccounts/staticWebsite`; Azure returned `HttpResourceNotFound`.

## Repair
- keeps infrastructure free of the invalid resource and preserves private ordinary Blob access
- enables `$web` with the supported `az storage blob service-properties update --auth-mode login` path only after Storage Blob Data Contributor preflight
- resolves the canonical web endpoint after enablement and verifies public style/tile delivery

## Verification
- `node --test tests/*.test.mjs` — 168 passed
- `az bicep build --file infra/main.bicep` (no BCP081)
- workflow YAML parse and `git diff --check`