### PR TITLE
fix(wardriver): preflight private publication container

### DIFF
--- a/.github/workflows/publish-wardriver-basemap.yml
+++ b/.github/workflows/publish-wardriver-basemap.yml
@@ -57,23 +57,25 @@ jobs:
             -o json)
           account=$(jq -r '.wardriverReleaseStorageAccountName.value' <<<"$outputs")
           container=$(jq -r '.wardriverBasemapContainerName.value' <<<"$outputs")
-          if ! [[ "$account" =~ ^[a-z0-9]{3,24}$ ]] || [ "$container" != '$web' ]; then
-            echo '::error::Deployed Wardriver basemap storage outputs are absent or violate the private-Blob contract.'
+          release_container=$(jq -r '.wardriverReleaseContainerName.value' <<<"$outputs")
+          if ! [[ "$account" =~ ^[a-z0-9]{3,24}$ ]] || [ "$container" != '$web' ] || [ "$release_container" != 'wardriver-releases' ]; then
+            echo '::error::Deployed Wardriver storage outputs are absent or violate the private-Blob contract.'
             exit 1
           fi
           echo 'This workflow requires Storage Blob Data Contributor on the Wardriver storage account only.'
           echo "account=$account" >> "$GITHUB_OUTPUT"
           echo "container=$container" >> "$GITHUB_OUTPUT"
+          echo "release_container=$release_container" >> "$GITHUB_OUTPUT"
 
       - name: Verify OIDC Blob data-plane access
         env:
           ACCOUNT: ${{ steps.basemap.outputs.account }}
-          CONTAINER: ${{ steps.basemap.outputs.container }}
+          CONTAINER: ${{ steps.basemap.outputs.release_container }}
         run: |
           set -euo pipefail
-          # Control-plane Contributor is insufficient for --auth-mode login uploads.
-          # The publication environment's OIDC principal must hold Storage Blob Data Contributor
-          # on this storage account; fail before downloading or rendering a large tile generation.
+          # $web does not exist until static-website enablement. Use the existing private
+          # release container to prove the scoped OIDC principal has Blob data-plane access
+          # before creating the public path or downloading/rendering a large tile generation.
           az storage container show --auth-mode login \
             --account-name "$ACCOUNT" \
             --name "$CONTAINER" \

--- a/specs/009-wardriver-maplibre-basemap/plan.md
+++ b/specs/009-wardriver-maplibre-basemap/plan.md
@@ -4,7 +4,7 @@
 
 1. Keep the dedicated Wardriver Blob account's ordinary anonymous access disabled. Keep the release container private; during protected manual publication, prove OIDC data-plane access then enable its `$web` static-website resource as the sole public read-only basemap path.
 2. Produce a MapLibre v8 style from `basemap/style.template.json`. The checked-in template has no remote tile origin. Publication renders a generation-specific BSS static-website tile base into the style.
-3. On protected manual dispatch, prove the OIDC principal can read `$web` before any expensive work; then download the bounded Washington Geofabrik PBF and its checksum, download Planetiler `v0.10.2` and its checksum, render vector MBTiles on Java 21, extract gzip XYZ PBF objects, and publish provenance plus immutable tiles.
+3. On protected manual dispatch, prove the OIDC principal can read the existing private `wardriver-releases` container before it enables `$web` or does any expensive work; then download the bounded Washington Geofabrik PBF and its checksum, download Planetiler `v0.10.2` and its checksum, render vector MBTiles on Java 21, extract gzip XYZ PBF objects, and publish provenance plus immutable tiles.
 4. Compile signed Wardriver `bss.15+` with `WIGLE_BSS_FORCE_MAPLIBRE=true` and the BSS static-website style endpoint. Ignore old renderer/style preferences on all MapLibre surfaces.
 5. Deploy the BSS infrastructure and publish the first source generation before creating a device candidate. Do not publish an APK or mutable release manifest before physical acceptance.
 

--- a/specs/009-wardriver-maplibre-basemap/spec.md
+++ b/specs/009-wardriver-maplibre-basemap/spec.md
@@ -35,7 +35,7 @@ A tile generation shall use a source/renderer/commit-derived prefix below `$web/
 
 ### R4 — Source and publication controls
 
-Publication shall run only by manual GitHub Actions dispatch in the protected `wardriver-basemap-publication` environment. The job shall use OIDC with a scoped `Storage Blob Data Contributor` role and must prove that data-plane access before it downloads or renders a tile generation. It shall verify the Geofabrik sidecar SHA-256 and Planetiler release SHA-256 before generation. It shall not accept an arbitrary input URL.
+Publication shall run only by manual GitHub Actions dispatch in the protected `wardriver-basemap-publication` environment. The job shall use OIDC with a scoped `Storage Blob Data Contributor` role and must prove that data-plane access against the existing private `wardriver-releases` container before it enables `$web`, downloads, or renders a tile generation. It shall verify the Geofabrik sidecar SHA-256 and Planetiler release SHA-256 before generation. It shall not accept an arbitrary input URL.
 
 ### R5 — Android renderer policy
 

--- a/specs/009-wardriver-maplibre-basemap/tasks.md
+++ b/specs/009-wardriver-maplibre-basemap/tasks.md
@@ -3,6 +3,7 @@
 - [x] Replace the policy-blocked public Blob container design with a `$web` static-website basemap path while preserving private release objects.
 - [x] Add BSS style template, immutable vector-tile extractor, style renderer, and provenance-capable publisher workflow.
 - [x] Check Bicep locally; run a Java 21 Planetiler canary and local static tests.
+- [x] Prove OIDC data-plane access against private `wardriver-releases` before enabling `$web` or fetching inputs.
 - [ ] Deploy infrastructure to Azure and run the protected first Washington publication.
 - [ ] Verify live public style/tile delivery and private release-object denial.
 - [ ] Build a signed `bss.15+` candidate using the BSS style endpoint.

--- a/specs/009-wardriver-maplibre-basemap/tests.md
+++ b/specs/009-wardriver-maplibre-basemap/tests.md
@@ -5,7 +5,7 @@
 | R1 | `tests/wardriver-basemap-delivery-config.test.mjs`; `az bicep build infra/main.bicep`; ordinary Blob access disabled and manual OIDC-gated `$web` enablement | implemented locally |
 | R2 | Style-template static contract; render-script canary with BSS static-website URL | implemented locally |
 | R3 | Publication workflow static contract checks versioned generation path, cache headers, provenance output | implemented locally |
-| R4 | Workflow static contract checks manual dispatch, OIDC data-plane preflight before source download, checksum verification, Java 21 | implemented locally |
+| R4 | Workflow static contract checks manual dispatch, OIDC preflight against private `wardriver-releases` before `$web` enablement/source download, checksum verification, Java 21 | implemented locally |
 | R5 | Wardriver `MapLibreReleaseContractTest` and `ReleasePromotionContractTest` | implemented locally; candidate build pending |
 | R6 | Physical device receipt for render/markers/location/outage/lifecycle/update | pending |
 

--- a/tests/wardriver-basemap-delivery-config.test.mjs
+++ b/tests/wardriver-basemap-delivery-config.test.mjs
@@ -63,7 +63,9 @@ test('manual basemap publication verifies its source and toolchain, emits proven
   assert.match(workflow, /expected_style_url_pattern/);
   assert.match(workflow, /primaryEndpoints\.web/);
   assert.match(workflow, /PUBLIC_PREFIX: wardriver-basemap/);
-  assert.match(workflow, /container" != '\$web'/);
+  assert.match(workflow, /wardriverReleaseContainerName/);
+  assert.match(workflow, /release_container/);
+  assert.match(workflow, /CONTAINER: \$\{\{ steps\.basemap\.outputs\.release_container \}\}/);
   assert.ok(
     workflow.indexOf('Verify OIDC Blob data-plane access') < workflow.indexOf('Fetch and verify bounded OpenStreetMap input'),
     'data-plane RBAC must fail before the expensive map build',


### PR DESCRIPTION
## Summary
- prove OIDC Blob data-plane access against the existing private release container
- enable `$web` only after that proof
- retain pre-download failure ordering and static publication contract

## Verification
- `node --test tests/*.test.mjs` (168 passed)
- `az bicep build --file infra/main.bicep`
- workflow YAML parse
- `git diff --check`