### PR TITLE
fix(wardriver): retrieve Planetiler via releases API

### DIFF
--- a/.github/workflows/publish-wardriver-basemap.yml
+++ b/.github/workflows/publish-wardriver-basemap.yml
@@ -113,6 +113,11 @@ jobs:
 
       - name: Fetch and verify bounded OpenStreetMap input and Planetiler
         id: inputs
+        env:
+          # Use the Releases API rather than anonymous browser asset redirects. The token is
+          # GitHub's ephemeral, repository-scoped workflow token; no release credential enters
+          # the generated tiles, provenance, or Android build.
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           work="$RUNNER_TEMP/wardriver-basemap"
@@ -122,10 +127,11 @@ jobs:
           curl --fail --location --retry 3 --retry-all-errors --output washington-latest.osm.pbf "$source_url"
           curl --fail --location --retry 3 --retry-all-errors --output washington-latest.osm.pbf.sha256 "$source_url.sha256"
           sha256sum --check washington-latest.osm.pbf.sha256
-          curl --fail --location --retry 3 --retry-all-errors --output planetiler.jar \
-            "https://github.com/onthegomap/planetiler/releases/download/${PLANETILER_VERSION}/planetiler.jar"
-          curl --fail --location --retry 3 --retry-all-errors --output planetiler.jar.sha256 \
-            "https://github.com/onthegomap/planetiler/releases/download/${PLANETILER_VERSION}/planetiler.jar.sha256"
+          gh release download "$PLANETILER_VERSION" \
+            --repo onthegomap/planetiler \
+            --pattern planetiler.jar \
+            --pattern planetiler.jar.sha256 \
+            --dir "$work"
           sha256sum --check planetiler.jar.sha256
           echo "source_url=$source_url" >> "$GITHUB_OUTPUT"
           echo "source_sha256=$(sha256sum washington-latest.osm.pbf | awk '{print $1}')" >> "$GITHUB_OUTPUT"

--- a/specs/009-wardriver-maplibre-basemap/plan.md
+++ b/specs/009-wardriver-maplibre-basemap/plan.md
@@ -4,7 +4,7 @@
 
 1. Keep the dedicated Wardriver Blob account's ordinary anonymous access disabled. Keep the release container private; during protected manual publication, prove OIDC data-plane access then enable its `$web` static-website resource as the sole public read-only basemap path.
 2. Produce a MapLibre v8 style from `basemap/style.template.json`. The checked-in template has no remote tile origin. Publication renders a generation-specific BSS static-website tile base into the style.
-3. On protected manual dispatch, prove the OIDC principal can read the existing private `wardriver-releases` container before it enables `$web` or does any expensive work; then download the bounded Washington Geofabrik PBF and its checksum, download Planetiler `v0.10.2` and its checksum, render vector MBTiles on Java 21, extract gzip XYZ PBF objects, and publish provenance plus immutable tiles.
+3. On protected manual dispatch, prove the OIDC principal can read the existing private `wardriver-releases` container before it enables `$web` or does any expensive work; then download the bounded Washington Geofabrik PBF and its checksum, fetch the pinned Planetiler `v0.10.2` JAR and sidecar through the GitHub Releases API using only the ephemeral workflow token, render vector MBTiles on Java 21, extract gzip XYZ PBF objects, and publish provenance plus immutable tiles.
 4. Compile signed Wardriver `bss.15+` with `WIGLE_BSS_FORCE_MAPLIBRE=true` and the BSS static-website style endpoint. Ignore old renderer/style preferences on all MapLibre surfaces.
 5. Deploy the BSS infrastructure and publish the first source generation before creating a device candidate. Do not publish an APK or mutable release manifest before physical acceptance.
 

--- a/specs/009-wardriver-maplibre-basemap/tests.md
+++ b/specs/009-wardriver-maplibre-basemap/tests.md
@@ -5,7 +5,7 @@
 | R1 | `tests/wardriver-basemap-delivery-config.test.mjs`; `az bicep build infra/main.bicep`; ordinary Blob access disabled and manual OIDC-gated `$web` enablement | implemented locally |
 | R2 | Style-template static contract; render-script canary with BSS static-website URL | implemented locally |
 | R3 | Publication workflow static contract checks versioned generation path, cache headers, provenance output | implemented locally |
-| R4 | Workflow static contract checks manual dispatch, OIDC preflight against private `wardriver-releases` before `$web` enablement/source download, checksum verification, Java 21 | implemented locally |
+| R4 | Workflow static contract checks manual dispatch, OIDC preflight against private `wardriver-releases` before `$web` enablement/source download, pinned Planetiler GitHub Releases API retrieval + checksum verification, Java 21 | implemented locally |
 | R5 | Wardriver `MapLibreReleaseContractTest` and `ReleasePromotionContractTest` | implemented locally; candidate build pending |
 | R6 | Physical device receipt for render/markers/location/outage/lifecycle/update | pending |
 

--- a/tests/wardriver-basemap-delivery-config.test.mjs
+++ b/tests/wardriver-basemap-delivery-config.test.mjs
@@ -48,7 +48,10 @@ test('manual basemap publication verifies its source and toolchain, emits proven
   assert.match(workflow, /workflow_dispatch/);
   assert.match(workflow, /washington/);
   assert.match(workflow, /download\.geofabrik\.de\/north-america\/us\/washington-latest\.osm\.pbf/);
-  assert.match(workflow, /planetiler\.jar\.sha256/);
+  assert.match(workflow, /gh release download "\$PLANETILER_VERSION"/);
+  assert.match(workflow, /--repo onthegomap\/planetiler/);
+  assert.match(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}/);
+  assert.doesNotMatch(workflow, /https:\/\/github\.com\/onthegomap\/planetiler\/releases\/download/);
   assert.match(workflow, /actions\/setup-java@v4/);
   assert.match(workflow, /java-version: '21'/);
   assert.match(workflow, /\$JAVA_HOME\/bin\/java/);


### PR DESCRIPTION
## Summary
- retrieve pinned Planetiler release assets through GitHub Releases API
- retain exact SHA-256 validation
- avoid unreliable anonymous browser release redirects on hosted runners

## Verification
- `node --test tests/*.test.mjs` (168 passed)
- local `gh release download v0.10.2` plus `sha256sum --check`
- `az bicep build --file infra/main.bicep`
- workflow YAML parse
- `git diff --check`