### PR TITLE
fix(wardriver): stage pinned basemap toolchain privately

### DIFF
--- a/.github/workflows/publish-wardriver-basemap.yml
+++ b/.github/workflows/publish-wardriver-basemap.yml
@@ -22,6 +22,7 @@ concurrency:
 env:
   RESOURCE_GROUP: rg-blue-swallow
   PLANETILER_VERSION: v0.10.2
+  PLANETILER_SHA256: f310bd0413e2e4512b27f4046d418664e8e1d3bf31603c2a70e23de06c167e4d
   # The policy blocks ordinary anonymous Blob access. The named $web static-website path is public read-only.
   PUBLIC_PREFIX: wardriver-basemap
   STYLE_OBJECT_PATH: v1/style.json
@@ -58,7 +59,8 @@ jobs:
           account=$(jq -r '.wardriverReleaseStorageAccountName.value' <<<"$outputs")
           container=$(jq -r '.wardriverBasemapContainerName.value' <<<"$outputs")
           release_container=$(jq -r '.wardriverReleaseContainerName.value' <<<"$outputs")
-          if ! [[ "$account" =~ ^[a-z0-9]{3,24}$ ]] || [ "$container" != '$web' ] || [ "$release_container" != 'wardriver-releases' ]; then
+          toolchain_container=$(jq -r '.wardriverBasemapToolchainContainerName.value' <<<"$outputs")
+          if ! [[ "$account" =~ ^[a-z0-9]{3,24}$ ]] || [ "$container" != '$web' ] || [ "$release_container" != 'wardriver-releases' ] || [ "$toolchain_container" != 'wardriver-basemap-toolchain' ]; then
             echo '::error::Deployed Wardriver storage outputs are absent or violate the private-Blob contract.'
             exit 1
           fi
@@ -66,6 +68,7 @@ jobs:
           echo "account=$account" >> "$GITHUB_OUTPUT"
           echo "container=$container" >> "$GITHUB_OUTPUT"
           echo "release_container=$release_container" >> "$GITHUB_OUTPUT"
+          echo "toolchain_container=$toolchain_container" >> "$GITHUB_OUTPUT"
 
       - name: Verify OIDC Blob data-plane access
         env:
@@ -81,6 +84,36 @@ jobs:
             --name "$CONTAINER" \
             --only-show-errors -o none
 
+      - name: Fetch and verify pinned private Planetiler toolchain
+        id: toolchain
+        env:
+          ACCOUNT: ${{ steps.basemap.outputs.account }}
+          TOOLCHAIN_CONTAINER: ${{ steps.basemap.outputs.toolchain_container }}
+        run: |
+          set -euo pipefail
+          work="$RUNNER_TEMP/wardriver-basemap"
+          mkdir -p "$work"
+          az storage blob download --auth-mode login \
+            --account-name "$ACCOUNT" \
+            --container-name "$TOOLCHAIN_CONTAINER" \
+            --name "planetiler/${PLANETILER_VERSION}/planetiler.jar" \
+            --file "$work/planetiler.jar" \
+            --only-show-errors -o none
+          az storage blob download --auth-mode login \
+            --account-name "$ACCOUNT" \
+            --container-name "$TOOLCHAIN_CONTAINER" \
+            --name "planetiler/${PLANETILER_VERSION}/planetiler-provenance.json" \
+            --file "$work/planetiler-provenance.json" \
+            --only-show-errors -o none
+          printf '%s  %s\n' "$PLANETILER_SHA256" "$work/planetiler.jar" | sha256sum --check --strict
+          jq -e \
+            --arg version "$PLANETILER_VERSION" \
+            --arg sha256 "$PLANETILER_SHA256" \
+            --arg source_url "https://github.com/onthegomap/planetiler/releases/download/${PLANETILER_VERSION}/planetiler.jar" \
+            '.schemaVersion == 1 and .name == "Planetiler" and .releaseTag == $version and .sourceUrl == $source_url and .sha256 == $sha256' \
+            "$work/planetiler-provenance.json" > /dev/null
+          echo "work=$work" >> "$GITHUB_OUTPUT"
+
       - name: Enable Storage static website
         id: static_website
         env:
@@ -88,7 +121,7 @@ jobs:
         run: |
           set -euo pipefail
           # $web is the policy-compliant public path. This data-plane operation is deliberately
-          # after the scoped OIDC proof and before any costly input download.
+          # after private OIDC/toolchain proof and before the costly source download.
           az storage blob service-properties update --auth-mode login \
             --account-name "$ACCOUNT" \
             --static-website true \
@@ -111,32 +144,20 @@ jobs:
           echo "style_url=$style_url" >> "$GITHUB_OUTPUT"
           echo "public_root=$public_root" >> "$GITHUB_OUTPUT"
 
-      - name: Fetch and verify bounded OpenStreetMap input and Planetiler
+      - name: Fetch and verify bounded OpenStreetMap input
         id: inputs
         env:
-          # Use the Releases API rather than anonymous browser asset redirects. The token is
-          # GitHub's ephemeral, repository-scoped workflow token; no release credential enters
-          # the generated tiles, provenance, or Android build.
-          GH_TOKEN: ${{ github.token }}
+          WORK: ${{ steps.toolchain.outputs.work }}
         run: |
           set -euo pipefail
-          work="$RUNNER_TEMP/wardriver-basemap"
-          mkdir -p "$work"
-          cd "$work"
+          cd "$WORK"
           source_url='https://download.geofabrik.de/north-america/us/washington-latest.osm.pbf'
           curl --fail --location --retry 3 --retry-all-errors --output washington-latest.osm.pbf "$source_url"
           curl --fail --location --retry 3 --retry-all-errors --output washington-latest.osm.pbf.sha256 "$source_url.sha256"
           sha256sum --check washington-latest.osm.pbf.sha256
-          gh release download "$PLANETILER_VERSION" \
-            --repo onthegomap/planetiler \
-            --pattern planetiler.jar \
-            --pattern planetiler.jar.sha256 \
-            --dir "$work"
-          sha256sum --check planetiler.jar.sha256
           echo "source_url=$source_url" >> "$GITHUB_OUTPUT"
           echo "source_sha256=$(sha256sum washington-latest.osm.pbf | awk '{print $1}')" >> "$GITHUB_OUTPUT"
-          echo "planetiler_sha256=$(sha256sum planetiler.jar | awk '{print $1}')" >> "$GITHUB_OUTPUT"
-          echo "work=$work" >> "$GITHUB_OUTPUT"
+          echo "work=$WORK" >> "$GITHUB_OUTPUT"
 
       - name: Generate and validate BSS vector tiles
         id: tiles
@@ -161,7 +182,8 @@ jobs:
           PUBLIC_ROOT: ${{ steps.static_website.outputs.public_root }}
           SOURCE_URL: ${{ steps.inputs.outputs.source_url }}
           SOURCE_SHA256: ${{ steps.inputs.outputs.source_sha256 }}
-          PLANETILER_SHA256: ${{ steps.inputs.outputs.planetiler_sha256 }}
+          TOOLCHAIN_CONTAINER: ${{ steps.basemap.outputs.toolchain_container }}
+          TOOLCHAIN_PROVENANCE_OBJECT: planetiler/${{ env.PLANETILER_VERSION }}/planetiler-provenance.json
           TILE_COUNT: ${{ steps.tiles.outputs.tile_count }}
         run: |
           set -euo pipefail
@@ -191,6 +213,11 @@ jobs:
               name: 'Planetiler',
               version: process.env.PLANETILER_VERSION,
               sha256: process.env.PLANETILER_SHA256,
+              toolchain: {
+                container: process.env.TOOLCHAIN_CONTAINER,
+                provenanceObject: process.env.TOOLCHAIN_PROVENANCE_OBJECT,
+                sourceUrl: `https://github.com/onthegomap/planetiler/releases/download/${process.env.PLANETILER_VERSION}/planetiler.jar`,
+              },
             },
             tileGeneration: process.env.generation,
             tileBaseUrl: process.env.tile_base_url,

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -197,6 +197,7 @@ output postgresStorageSizeGiB int = postgresModule.outputs.storageSizeGiB
 output postgresGeoRedundantBackup string = postgresModule.outputs.geoRedundantBackup
 output wardriverReleaseStorageAccountName string = wardriverReleaseStorage.outputs.storageAccountName
 output wardriverReleaseContainerName string = wardriverReleaseStorage.outputs.releaseContainerName
+output wardriverBasemapToolchainContainerName string = wardriverReleaseStorage.outputs.basemapToolchainContainerName
 output wardriverBasemapContainerName string = wardriverReleaseStorage.outputs.basemapContainerName
 output postgresHighAvailabilityMode string = postgresModule.outputs.highAvailabilityMode
 output openAiDeployed bool = deployOpenAi

--- a/infra/modules/wardriver-release-storage.bicep
+++ b/infra/modules/wardriver-release-storage.bicep
@@ -10,6 +10,9 @@ param containerName string = 'wardriver-releases'
 @description('The system $web container. It exposes only static website paths; ordinary Blob containers remain private.')
 param basemapContainerName string = '$web'
 
+@description('Private container holding checksum-pinned Planetiler toolchain inputs for the protected basemap publisher.')
+param toolchainContainerName string = 'wardriver-basemap-toolchain'
+
 var storageAccountName = toLower('bsswd${uniqueString(subscription().id, resourceGroup().id, prefix)}')
 
 resource releaseStorage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
@@ -85,8 +88,17 @@ resource releaseContainer 'Microsoft.Storage/storageAccounts/blobServices/contai
   }
 }
 
+resource basemapToolchainContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: toolchainContainerName
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
 // `$web` is enabled only by the protected publisher after OIDC data-plane proof.
 
 output storageAccountName string = releaseStorage.name
 output releaseContainerName string = releaseContainer.name
+output basemapToolchainContainerName string = basemapToolchainContainer.name
 output basemapContainerName string = basemapContainerName

--- a/specs/009-wardriver-maplibre-basemap/plan.md
+++ b/specs/009-wardriver-maplibre-basemap/plan.md
@@ -2,9 +2,9 @@
 
 ## Implementation approach
 
-1. Keep the dedicated Wardriver Blob account's ordinary anonymous access disabled. Keep the release container private; during protected manual publication, prove OIDC data-plane access then enable its `$web` static-website resource as the sole public read-only basemap path.
+1. Keep the dedicated Wardriver Blob account's ordinary anonymous access disabled. Keep the release and checksum-pinned toolchain containers private; during protected manual publication, prove OIDC data-plane access, validate the pre-staged private toolchain, then enable its `$web` static-website resource as the sole public read-only basemap path.
 2. Produce a MapLibre v8 style from `basemap/style.template.json`. The checked-in template has no remote tile origin. Publication renders a generation-specific BSS static-website tile base into the style.
-3. On protected manual dispatch, prove the OIDC principal can read the existing private `wardriver-releases` container before it enables `$web` or does any expensive work; then download the bounded Washington Geofabrik PBF and its checksum, fetch the pinned Planetiler `v0.10.2` JAR and sidecar through the GitHub Releases API using only the ephemeral workflow token, render vector MBTiles on Java 21, extract gzip XYZ PBF objects, and publish provenance plus immutable tiles.
+3. On protected manual dispatch, prove the OIDC principal can read the existing private `wardriver-releases` container before it does any work; then download the pre-staged private `wardriver-basemap-toolchain/planetiler/v0.10.2` JAR, verify its fixed SHA-256 and source-provenance record, enable `$web`, download the bounded Washington Geofabrik PBF plus its checksum, render vector MBTiles on Java 21, extract gzip XYZ PBF objects, and publish provenance plus immutable tiles.
 4. Compile signed Wardriver `bss.15+` with `WIGLE_BSS_FORCE_MAPLIBRE=true` and the BSS static-website style endpoint. Ignore old renderer/style preferences on all MapLibre surfaces.
 5. Deploy the BSS infrastructure and publish the first source generation before creating a device candidate. Do not publish an APK or mutable release manifest before physical acceptance.
 
@@ -13,6 +13,7 @@
 | Object | Access | Mutability | Cache |
 |---|---|---|---|
 | `wardriver-releases/*` | authenticated/SAS | immutable release objects | existing release policy |
+| `wardriver-basemap-toolchain/planetiler/v0.10.2/{planetiler.jar,planetiler-provenance.json}` | OIDC only | immutable checksum-pinned toolchain inputs | no public delivery |
 | `$web/wardriver-basemap/v1/generations/<id>/tiles/*` | public named static-website object | immutable | `public, max-age=31536000, immutable` |
 | `$web/wardriver-basemap/v1/generations/<id>/basemap-provenance.json` | public named static-website object | immutable | `public, max-age=31536000, immutable` |
 | `$web/wardriver-basemap/v1/style.json` | public named static-website object | versioned current pointer | `no-store` |
@@ -23,7 +24,7 @@ No Function handles a tile request. This prevents application-level location log
 ## Rollout sequence
 
 1. Merge infrastructure/style/publisher source after review.
-2. Deploy BSS infrastructure. Verify `style.json` is absent until a signed publication intentionally creates it.
+2. Deploy BSS infrastructure, stage the verified private Planetiler toolchain with its source provenance, and verify `style.json` is absent until a signed publication intentionally creates it.
 3. Run one protected Washington basemap publication. Verify public style and sample tile headers, provenance, attribution, and no anonymous release-object access.
 4. Merge the Android policy. Build a signed `bss.15+` candidate after the BSS style exists.
 5. Perform physical Android acceptance. Only then create the immutable tag, SHA-256 receipt, and current-release promotion.

--- a/specs/009-wardriver-maplibre-basemap/spec.md
+++ b/specs/009-wardriver-maplibre-basemap/spec.md
@@ -17,7 +17,7 @@ This specification owns observable basemap behavior for Wardriver `bss.15+`.
 
 ### R1 — Public static-website paths; private Blob containers
 
-The existing Wardriver storage account shall set `allowBlobPublicAccess: false`. The existing `wardriver-releases` container shall remain `publicAccess: 'None'`. The protected manual publisher shall enable the Storage static website and upload basemap bytes under its system `$web` container; clients read only through explicit static-website object paths, while ordinary Blob listing remains unauthenticated-denied.
+The existing Wardriver storage account shall set `allowBlobPublicAccess: false`. The existing `wardriver-releases` and `wardriver-basemap-toolchain` containers shall remain `publicAccess: 'None'`. The latter holds the checksum-pinned Planetiler JAR and its source provenance; it is never a public map or APK path. The protected manual publisher shall enable the Storage static website and upload basemap bytes under its system `$web` container; clients read only through explicit static-website object paths, while ordinary Blob listing remains unauthenticated-denied.
 
 ### R2 — Client style endpoint
 
@@ -35,7 +35,7 @@ A tile generation shall use a source/renderer/commit-derived prefix below `$web/
 
 ### R4 — Source and publication controls
 
-Publication shall run only by manual GitHub Actions dispatch in the protected `wardriver-basemap-publication` environment. The job shall use OIDC with a scoped `Storage Blob Data Contributor` role and must prove that data-plane access against the existing private `wardriver-releases` container before it enables `$web`, downloads, or renders a tile generation. It shall verify the Geofabrik sidecar SHA-256 and Planetiler release SHA-256 before generation. It shall not accept an arbitrary input URL.
+Publication shall run only by manual GitHub Actions dispatch in the protected `wardriver-basemap-publication` environment. The job shall use OIDC with a scoped `Storage Blob Data Contributor` role and must prove that data-plane access against the existing private `wardriver-releases` container before it enables `$web`, downloads, or renders a tile generation. It shall fetch Planetiler `v0.10.2` only from the private `wardriver-basemap-toolchain` container, validate its fixed SHA-256 and source-provenance record, and verify the Geofabrik sidecar SHA-256 before generation. It shall not accept an arbitrary input URL.
 
 ### R5 — Android renderer policy
 

--- a/specs/009-wardriver-maplibre-basemap/tasks.md
+++ b/specs/009-wardriver-maplibre-basemap/tasks.md
@@ -4,6 +4,7 @@
 - [x] Add BSS style template, immutable vector-tile extractor, style renderer, and provenance-capable publisher workflow.
 - [x] Check Bicep locally; run a Java 21 Planetiler canary and local static tests.
 - [x] Prove OIDC data-plane access against private `wardriver-releases` before enabling `$web` or fetching inputs.
+- [ ] Deploy the private toolchain container and stage its verified, checksum-pinned Planetiler `v0.10.2` JAR plus source provenance.
 - [ ] Deploy infrastructure to Azure and run the protected first Washington publication.
 - [ ] Verify live public style/tile delivery and private release-object denial.
 - [ ] Build a signed `bss.15+` candidate using the BSS style endpoint.

--- a/specs/009-wardriver-maplibre-basemap/tests.md
+++ b/specs/009-wardriver-maplibre-basemap/tests.md
@@ -2,13 +2,13 @@
 
 | Requirement | Test / evidence | Status |
 |---|---|---|
-| R1 | `tests/wardriver-basemap-delivery-config.test.mjs`; `az bicep build infra/main.bicep`; ordinary Blob access disabled and manual OIDC-gated `$web` enablement | implemented locally |
+| R1 | `tests/wardriver-basemap-delivery-config.test.mjs`; `az bicep build infra/main.bicep`; ordinary Blob access disabled, release/toolchain containers private, and manual OIDC-gated `$web` enablement | implemented locally |
 | R2 | Style-template static contract; render-script canary with BSS static-website URL | implemented locally |
 | R3 | Publication workflow static contract checks versioned generation path, cache headers, provenance output | implemented locally |
-| R4 | Workflow static contract checks manual dispatch, OIDC preflight against private `wardriver-releases` before `$web` enablement/source download, pinned Planetiler GitHub Releases API retrieval + checksum verification, Java 21 | implemented locally |
+| R4 | Workflow static contract checks manual dispatch, OIDC preflight against private `wardriver-releases`, fixed-SHA/private-toolchain provenance verification before `$web` enablement/source download, Geofabrik checksum verification, and Java 21 | implemented locally |
 | R5 | Wardriver `MapLibreReleaseContractTest` and `ReleasePromotionContractTest` | implemented locally; candidate build pending |
 | R6 | Physical device receipt for render/markers/location/outage/lifecycle/update | pending |
 
 ## Local canary
 
-Planetiler `v0.10.2` was checksum-verified and run against its Monaco download fixture with Java 21. The extractor emitted 246 gzip PBF tiles across zoom 0–14 and confirmed `water` and `transportation` source layers. The rendered style referenced only the supplied BSS static-website URL.
+Planetiler `v0.10.2` was checksum-verified from its upstream release and matched the fixed private-toolchain checksum/provenance contract; it was then run against its Monaco download fixture with Java 21. The extractor emitted 246 gzip PBF tiles across zoom 0–14 and confirmed `water` and `transportation` source layers. The rendered style referenced only the supplied BSS static-website URL.

--- a/tests/wardriver-basemap-delivery-config.test.mjs
+++ b/tests/wardriver-basemap-delivery-config.test.mjs
@@ -20,6 +20,9 @@ test('Bicep keeps ordinary release blobs private and reserves $web for the manua
   assert.match(storage, /allowBlobPublicAccess:\s*false/);
   assert.doesNotMatch(storage, /resource basemapStaticWebsite/);
   assert.match(storage, /resource releaseContainer[\s\S]*?publicAccess:\s*'None'/);
+  assert.match(storage, /resource basemapToolchainContainer[\s\S]*?publicAccess:\s*'None'/);
+  assert.match(storage, /toolchainContainerName string = 'wardriver-basemap-toolchain'/);
+  assert.match(main, /wardriverBasemapToolchainContainerName/);
   assert.doesNotMatch(storage, /publicAccess:\s*'Blob'/);
   assert.match(storage, /basemapContainerName string = '\$web'/);
   assert.doesNotMatch(storage, /wardriverBasemapStyleUrl/);
@@ -48,10 +51,18 @@ test('manual basemap publication verifies its source and toolchain, emits proven
   assert.match(workflow, /workflow_dispatch/);
   assert.match(workflow, /washington/);
   assert.match(workflow, /download\.geofabrik\.de\/north-america\/us\/washington-latest\.osm\.pbf/);
-  assert.match(workflow, /gh release download "\$PLANETILER_VERSION"/);
-  assert.match(workflow, /--repo onthegomap\/planetiler/);
-  assert.match(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}/);
-  assert.doesNotMatch(workflow, /https:\/\/github\.com\/onthegomap\/planetiler\/releases\/download/);
+  assert.match(workflow, /PLANETILER_VERSION: v0\.10\.2/);
+  assert.match(workflow, /PLANETILER_SHA256: f310bd0413e2e4512b27f4046d418664e8e1d3bf31603c2a70e23de06c167e4d/);
+  assert.match(workflow, /wardriverBasemapToolchainContainerName/);
+  assert.match(workflow, /toolchain_container/);
+  assert.match(workflow, /Fetch and verify pinned private Planetiler toolchain/);
+  assert.match(workflow, /--container-name "\$TOOLCHAIN_CONTAINER"/);
+  assert.match(workflow, /planetiler\/\$\{PLANETILER_VERSION\}\/planetiler\.jar/);
+  assert.match(workflow, /planetiler-provenance\.json/);
+  assert.match(workflow, /sha256sum --check --strict/);
+  assert.doesNotMatch(workflow, /gh release download/);
+  assert.doesNotMatch(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}/);
+  assert.doesNotMatch(workflow, /curl[^\n]*github\.com\/onthegomap\/planetiler/);
   assert.match(workflow, /actions\/setup-java@v4/);
   assert.match(workflow, /java-version: '21'/);
   assert.match(workflow, /\$JAVA_HOME\/bin\/java/);
@@ -70,8 +81,12 @@ test('manual basemap publication verifies its source and toolchain, emits proven
   assert.match(workflow, /release_container/);
   assert.match(workflow, /CONTAINER: \$\{\{ steps\.basemap\.outputs\.release_container \}\}/);
   assert.ok(
-    workflow.indexOf('Verify OIDC Blob data-plane access') < workflow.indexOf('Fetch and verify bounded OpenStreetMap input'),
-    'data-plane RBAC must fail before the expensive map build',
+    workflow.indexOf('Verify OIDC Blob data-plane access') < workflow.indexOf('Fetch and verify pinned private Planetiler toolchain'),
+    'data-plane RBAC must fail before the private toolchain read',
+  );
+  assert.ok(
+    workflow.indexOf('Fetch and verify pinned private Planetiler toolchain') < workflow.indexOf('Enable Storage static website'),
+    'the private toolchain must validate before public-host enablement',
   );
   assert.ok(
     workflow.indexOf('Enable Storage static website') < workflow.indexOf('Fetch and verify bounded OpenStreetMap input'),


### PR DESCRIPTION
## Summary
- add a private, non-public Planetiler toolchain container
- pin Planetiler v0.10.2 by fixed SHA-256 and source-provenance record
- make OIDC publisher consume the private toolchain before static hosting or map-source download

## Verification
- `node --test tests/*.test.mjs` (168 passed)
- `az bicep build --file infra/main.bicep`
- workflow YAML and each Bash step syntax
- private-toolchain SHA/provenance canary
- `git diff --check`