### PR TITLE
fix(wardriver): consume pinned private Washington input

### DIFF
--- a/.github/workflows/publish-wardriver-basemap.yml
+++ b/.github/workflows/publish-wardriver-basemap.yml
@@ -23,6 +23,7 @@ env:
   RESOURCE_GROUP: rg-blue-swallow
   PLANETILER_VERSION: v0.10.2
   PLANETILER_SHA256: f310bd0413e2e4512b27f4046d418664e8e1d3bf31603c2a70e23de06c167e4d
+  WASHINGTON_SOURCE_SHA256: b6cc3930b0219882a21f5affe40974ec67b2b92178b90bb2030f492e6b57ad7f
   # The policy blocks ordinary anonymous Blob access. The named $web static-website path is public read-only.
   PUBLIC_PREFIX: wardriver-basemap
   STYLE_OBJECT_PATH: v1/style.json
@@ -60,7 +61,8 @@ jobs:
           container=$(jq -r '.wardriverBasemapContainerName.value' <<<"$outputs")
           release_container=$(jq -r '.wardriverReleaseContainerName.value' <<<"$outputs")
           toolchain_container=$(jq -r '.wardriverBasemapToolchainContainerName.value' <<<"$outputs")
-          if ! [[ "$account" =~ ^[a-z0-9]{3,24}$ ]] || [ "$container" != '$web' ] || [ "$release_container" != 'wardriver-releases' ] || [ "$toolchain_container" != 'wardriver-basemap-toolchain' ]; then
+          input_container=$(jq -r '.wardriverBasemapInputContainerName.value' <<<"$outputs")
+          if ! [[ "$account" =~ ^[a-z0-9]{3,24}$ ]] || [ "$container" != '$web' ] || [ "$release_container" != 'wardriver-releases' ] || [ "$toolchain_container" != 'wardriver-basemap-toolchain' ] || [ "$input_container" != 'wardriver-basemap-inputs' ]; then
             echo '::error::Deployed Wardriver storage outputs are absent or violate the private-Blob contract.'
             exit 1
           fi
@@ -69,6 +71,7 @@ jobs:
           echo "container=$container" >> "$GITHUB_OUTPUT"
           echo "release_container=$release_container" >> "$GITHUB_OUTPUT"
           echo "toolchain_container=$toolchain_container" >> "$GITHUB_OUTPUT"
+          echo "input_container=$input_container" >> "$GITHUB_OUTPUT"
 
       - name: Verify OIDC Blob data-plane access
         env:
@@ -144,19 +147,35 @@ jobs:
           echo "style_url=$style_url" >> "$GITHUB_OUTPUT"
           echo "public_root=$public_root" >> "$GITHUB_OUTPUT"
 
-      - name: Fetch and verify bounded OpenStreetMap input
+      - name: Fetch and verify private Washington input
         id: inputs
         env:
+          ACCOUNT: ${{ steps.basemap.outputs.account }}
+          INPUT_CONTAINER: ${{ steps.basemap.outputs.input_container }}
           WORK: ${{ steps.toolchain.outputs.work }}
         run: |
           set -euo pipefail
-          cd "$WORK"
           source_url='https://download.geofabrik.de/north-america/us/washington-latest.osm.pbf'
-          curl --fail --location --retry 3 --retry-all-errors --output washington-latest.osm.pbf "$source_url"
-          curl --fail --location --retry 3 --retry-all-errors --output washington-latest.osm.pbf.sha256 "$source_url.sha256"
-          sha256sum --check washington-latest.osm.pbf.sha256
+          az storage blob download --auth-mode login \
+            --account-name "$ACCOUNT" \
+            --container-name "$INPUT_CONTAINER" \
+            --name geofabrik/washington/washington.osm.pbf \
+            --file "$WORK/washington.osm.pbf" \
+            --only-show-errors -o none
+          az storage blob download --auth-mode login \
+            --account-name "$ACCOUNT" \
+            --container-name "$INPUT_CONTAINER" \
+            --name geofabrik/washington/washington-provenance.json \
+            --file "$WORK/washington-provenance.json" \
+            --only-show-errors -o none
+          printf '%s  %s\n' "$WASHINGTON_SOURCE_SHA256" "$WORK/washington.osm.pbf" | sha256sum --check --strict
+          jq -e \
+            --arg sha256 "$WASHINGTON_SOURCE_SHA256" \
+            --arg source_url "$source_url" \
+            '.schemaVersion == 1 and .name == "Geofabrik Washington OpenStreetMap extract" and .sourceUrl == $source_url and .sha256 == $sha256 and .license == "ODbL-1.0" and .attribution == "© OpenStreetMap contributors"' \
+            "$WORK/washington-provenance.json" > /dev/null
           echo "source_url=$source_url" >> "$GITHUB_OUTPUT"
-          echo "source_sha256=$(sha256sum washington-latest.osm.pbf | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+          echo "source_sha256=$WASHINGTON_SOURCE_SHA256" >> "$GITHUB_OUTPUT"
           echo "work=$WORK" >> "$GITHUB_OUTPUT"
 
       - name: Generate and validate BSS vector tiles
@@ -166,7 +185,7 @@ jobs:
         run: |
           set -euo pipefail
           "$JAVA_HOME/bin/java" -Xmx6g -jar "$WORK/planetiler.jar" \
-            --osm-path="$WORK/washington-latest.osm.pbf" \
+            --osm-path="$WORK/washington.osm.pbf" \
             --output="$WORK/washington.mbtiles"
           python3 scripts/extract-mbtiles-tiles.py \
             "$WORK/washington.mbtiles" \
@@ -182,6 +201,8 @@ jobs:
           PUBLIC_ROOT: ${{ steps.static_website.outputs.public_root }}
           SOURCE_URL: ${{ steps.inputs.outputs.source_url }}
           SOURCE_SHA256: ${{ steps.inputs.outputs.source_sha256 }}
+          INPUT_CONTAINER: ${{ steps.basemap.outputs.input_container }}
+          INPUT_PROVENANCE_OBJECT: geofabrik/washington/washington-provenance.json
           TOOLCHAIN_CONTAINER: ${{ steps.basemap.outputs.toolchain_container }}
           TOOLCHAIN_PROVENANCE_OBJECT: planetiler/${{ env.PLANETILER_VERSION }}/planetiler-provenance.json
           TILE_COUNT: ${{ steps.tiles.outputs.tile_count }}
@@ -208,6 +229,10 @@ jobs:
               sha256: process.env.SOURCE_SHA256,
               license: 'ODbL-1.0',
               attribution: '© OpenStreetMap contributors',
+              privateInput: {
+                container: process.env.INPUT_CONTAINER,
+                provenanceObject: process.env.INPUT_PROVENANCE_OBJECT,
+              },
             },
             generator: {
               name: 'Planetiler',

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -198,6 +198,7 @@ output postgresGeoRedundantBackup string = postgresModule.outputs.geoRedundantBa
 output wardriverReleaseStorageAccountName string = wardriverReleaseStorage.outputs.storageAccountName
 output wardriverReleaseContainerName string = wardriverReleaseStorage.outputs.releaseContainerName
 output wardriverBasemapToolchainContainerName string = wardriverReleaseStorage.outputs.basemapToolchainContainerName
+output wardriverBasemapInputContainerName string = wardriverReleaseStorage.outputs.basemapInputContainerName
 output wardriverBasemapContainerName string = wardriverReleaseStorage.outputs.basemapContainerName
 output postgresHighAvailabilityMode string = postgresModule.outputs.highAvailabilityMode
 output openAiDeployed bool = deployOpenAi

--- a/infra/modules/wardriver-release-storage.bicep
+++ b/infra/modules/wardriver-release-storage.bicep
@@ -13,6 +13,9 @@ param basemapContainerName string = '$web'
 @description('Private container holding checksum-pinned Planetiler toolchain inputs for the protected basemap publisher.')
 param toolchainContainerName string = 'wardriver-basemap-toolchain'
 
+@description('Private container holding a verified Washington OSM extract and source provenance for the protected publisher.')
+param inputContainerName string = 'wardriver-basemap-inputs'
+
 var storageAccountName = toLower('bsswd${uniqueString(subscription().id, resourceGroup().id, prefix)}')
 
 resource releaseStorage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
@@ -96,9 +99,18 @@ resource basemapToolchainContainer 'Microsoft.Storage/storageAccounts/blobServic
   }
 }
 
+resource basemapInputContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: inputContainerName
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
 // `$web` is enabled only by the protected publisher after OIDC data-plane proof.
 
 output storageAccountName string = releaseStorage.name
 output releaseContainerName string = releaseContainer.name
 output basemapToolchainContainerName string = basemapToolchainContainer.name
+output basemapInputContainerName string = basemapInputContainer.name
 output basemapContainerName string = basemapContainerName

--- a/specs/009-wardriver-maplibre-basemap/plan.md
+++ b/specs/009-wardriver-maplibre-basemap/plan.md
@@ -2,9 +2,9 @@
 
 ## Implementation approach
 
-1. Keep the dedicated Wardriver Blob account's ordinary anonymous access disabled. Keep the release and checksum-pinned toolchain containers private; during protected manual publication, prove OIDC data-plane access, validate the pre-staged private toolchain, then enable its `$web` static-website resource as the sole public read-only basemap path.
+1. Keep the dedicated Wardriver Blob account's ordinary anonymous access disabled. Keep the release, checksum-pinned toolchain, and verified input containers private; during protected manual publication, prove OIDC data-plane access, validate the pre-staged private toolchain and Washington source, then enable its `$web` static-website resource as the sole public read-only basemap path.
 2. Produce a MapLibre v8 style from `basemap/style.template.json`. The checked-in template has no remote tile origin. Publication renders a generation-specific BSS static-website tile base into the style.
-3. On protected manual dispatch, prove the OIDC principal can read the existing private `wardriver-releases` container before it does any work; then download the pre-staged private `wardriver-basemap-toolchain/planetiler/v0.10.2` JAR, verify its fixed SHA-256 and source-provenance record, enable `$web`, download the bounded Washington Geofabrik PBF plus its checksum, render vector MBTiles on Java 21, extract gzip XYZ PBF objects, and publish provenance plus immutable tiles.
+3. On protected manual dispatch, prove the OIDC principal can read the existing private `wardriver-releases` container before it does any work; then download the pre-staged private `wardriver-basemap-toolchain/planetiler/v0.10.2` JAR and `wardriver-basemap-inputs/geofabrik/washington` PBF, verify their fixed SHA-256 values and source-provenance records, enable `$web`, render vector MBTiles on Java 21, extract gzip XYZ PBF objects, and publish provenance plus immutable tiles.
 4. Compile signed Wardriver `bss.15+` with `WIGLE_BSS_FORCE_MAPLIBRE=true` and the BSS static-website style endpoint. Ignore old renderer/style preferences on all MapLibre surfaces.
 5. Deploy the BSS infrastructure and publish the first source generation before creating a device candidate. Do not publish an APK or mutable release manifest before physical acceptance.
 
@@ -14,6 +14,7 @@
 |---|---|---|---|
 | `wardriver-releases/*` | authenticated/SAS | immutable release objects | existing release policy |
 | `wardriver-basemap-toolchain/planetiler/v0.10.2/{planetiler.jar,planetiler-provenance.json}` | OIDC only | immutable checksum-pinned toolchain inputs | no public delivery |
+| `wardriver-basemap-inputs/geofabrik/washington/{washington.osm.pbf,washington-provenance.json}` | OIDC only | immutable checksum-pinned OSM source input | no public delivery |
 | `$web/wardriver-basemap/v1/generations/<id>/tiles/*` | public named static-website object | immutable | `public, max-age=31536000, immutable` |
 | `$web/wardriver-basemap/v1/generations/<id>/basemap-provenance.json` | public named static-website object | immutable | `public, max-age=31536000, immutable` |
 | `$web/wardriver-basemap/v1/style.json` | public named static-website object | versioned current pointer | `no-store` |

--- a/specs/009-wardriver-maplibre-basemap/spec.md
+++ b/specs/009-wardriver-maplibre-basemap/spec.md
@@ -17,7 +17,7 @@ This specification owns observable basemap behavior for Wardriver `bss.15+`.
 
 ### R1 — Public static-website paths; private Blob containers
 
-The existing Wardriver storage account shall set `allowBlobPublicAccess: false`. The existing `wardriver-releases` and `wardriver-basemap-toolchain` containers shall remain `publicAccess: 'None'`. The latter holds the checksum-pinned Planetiler JAR and its source provenance; it is never a public map or APK path. The protected manual publisher shall enable the Storage static website and upload basemap bytes under its system `$web` container; clients read only through explicit static-website object paths, while ordinary Blob listing remains unauthenticated-denied.
+The existing Wardriver storage account shall set `allowBlobPublicAccess: false`. The existing `wardriver-releases`, `wardriver-basemap-toolchain`, and `wardriver-basemap-inputs` containers shall remain `publicAccess: 'None'`. The latter two hold the checksum-pinned Planetiler JAR/source provenance and a verified Washington OSM extract/source provenance; neither is a public map or APK path. The protected manual publisher shall enable the Storage static website and upload basemap bytes under its system `$web` container; clients read only through explicit static-website object paths, while ordinary Blob listing remains unauthenticated-denied.
 
 ### R2 — Client style endpoint
 
@@ -35,7 +35,7 @@ A tile generation shall use a source/renderer/commit-derived prefix below `$web/
 
 ### R4 — Source and publication controls
 
-Publication shall run only by manual GitHub Actions dispatch in the protected `wardriver-basemap-publication` environment. The job shall use OIDC with a scoped `Storage Blob Data Contributor` role and must prove that data-plane access against the existing private `wardriver-releases` container before it enables `$web`, downloads, or renders a tile generation. It shall fetch Planetiler `v0.10.2` only from the private `wardriver-basemap-toolchain` container, validate its fixed SHA-256 and source-provenance record, and verify the Geofabrik sidecar SHA-256 before generation. It shall not accept an arbitrary input URL.
+Publication shall run only by manual GitHub Actions dispatch in the protected `wardriver-basemap-publication` environment. The job shall use OIDC with a scoped `Storage Blob Data Contributor` role and must prove that data-plane access against the existing private `wardriver-releases` container before it enables `$web`, downloads, or renders a tile generation. It shall fetch Planetiler `v0.10.2` only from the private `wardriver-basemap-toolchain` container, validate its fixed SHA-256 and source-provenance record, and fetch the Washington extract only from private `wardriver-basemap-inputs`, validating its fixed SHA-256 plus ODbL/source-provenance record before generation. It shall not accept an arbitrary input URL.
 
 ### R5 — Android renderer policy
 

--- a/specs/009-wardriver-maplibre-basemap/tasks.md
+++ b/specs/009-wardriver-maplibre-basemap/tasks.md
@@ -4,9 +4,8 @@
 - [x] Add BSS style template, immutable vector-tile extractor, style renderer, and provenance-capable publisher workflow.
 - [x] Check Bicep locally; run a Java 21 Planetiler canary and local static tests.
 - [x] Prove OIDC data-plane access against private `wardriver-releases` before enabling `$web` or fetching inputs.
-- [ ] Deploy the private toolchain container and stage its verified, checksum-pinned Planetiler `v0.10.2` JAR plus source provenance.
-- [ ] Deploy infrastructure to Azure and run the protected first Washington publication.
-- [ ] Verify live public style/tile delivery and private release-object denial.
+- [ ] Deploy the private input container and stage its verified, checksum-pinned Washington OSM extract plus source provenance.
+- [ ] Run the protected first Washington publication; verify live public style/tile delivery and private release-object denial.
 - [ ] Build a signed `bss.15+` candidate using the BSS style endpoint.
 - [ ] Complete physical Android acceptance.
 - [ ] Tag and promote only after the physical gate.

--- a/specs/009-wardriver-maplibre-basemap/tests.md
+++ b/specs/009-wardriver-maplibre-basemap/tests.md
@@ -2,10 +2,10 @@
 
 | Requirement | Test / evidence | Status |
 |---|---|---|
-| R1 | `tests/wardriver-basemap-delivery-config.test.mjs`; `az bicep build infra/main.bicep`; ordinary Blob access disabled, release/toolchain containers private, and manual OIDC-gated `$web` enablement | implemented locally |
+| R1 | `tests/wardriver-basemap-delivery-config.test.mjs`; `az bicep build infra/main.bicep`; ordinary Blob access disabled, release/toolchain/input containers private, and manual OIDC-gated `$web` enablement | implemented locally |
 | R2 | Style-template static contract; render-script canary with BSS static-website URL | implemented locally |
 | R3 | Publication workflow static contract checks versioned generation path, cache headers, provenance output | implemented locally |
-| R4 | Workflow static contract checks manual dispatch, OIDC preflight against private `wardriver-releases`, fixed-SHA/private-toolchain provenance verification before `$web` enablement/source download, Geofabrik checksum verification, and Java 21 | implemented locally |
+| R4 | Workflow static contract checks manual dispatch, OIDC preflight against private `wardriver-releases`, fixed-SHA/private-toolchain and Washington-input provenance verification before `$web` enablement/generation, immutable generation paths, cache headers, style/object public probes, and CORS | implemented locally; live dispatch pending |
 | R5 | Wardriver `MapLibreReleaseContractTest` and `ReleasePromotionContractTest` | implemented locally; candidate build pending |
 | R6 | Physical device receipt for render/markers/location/outage/lifecycle/update | pending |
 

--- a/tests/wardriver-basemap-delivery-config.test.mjs
+++ b/tests/wardriver-basemap-delivery-config.test.mjs
@@ -21,8 +21,11 @@ test('Bicep keeps ordinary release blobs private and reserves $web for the manua
   assert.doesNotMatch(storage, /resource basemapStaticWebsite/);
   assert.match(storage, /resource releaseContainer[\s\S]*?publicAccess:\s*'None'/);
   assert.match(storage, /resource basemapToolchainContainer[\s\S]*?publicAccess:\s*'None'/);
+  assert.match(storage, /resource basemapInputContainer[\s\S]*?publicAccess:\s*'None'/);
   assert.match(storage, /toolchainContainerName string = 'wardriver-basemap-toolchain'/);
+  assert.match(storage, /inputContainerName string = 'wardriver-basemap-inputs'/);
   assert.match(main, /wardriverBasemapToolchainContainerName/);
+  assert.match(main, /wardriverBasemapInputContainerName/);
   assert.doesNotMatch(storage, /publicAccess:\s*'Blob'/);
   assert.match(storage, /basemapContainerName string = '\$web'/);
   assert.doesNotMatch(storage, /wardriverBasemapStyleUrl/);
@@ -55,6 +58,13 @@ test('manual basemap publication verifies its source and toolchain, emits proven
   assert.match(workflow, /PLANETILER_SHA256: f310bd0413e2e4512b27f4046d418664e8e1d3bf31603c2a70e23de06c167e4d/);
   assert.match(workflow, /wardriverBasemapToolchainContainerName/);
   assert.match(workflow, /toolchain_container/);
+  assert.match(workflow, /WASHINGTON_SOURCE_SHA256: b6cc3930b0219882a21f5affe40974ec67b2b92178b90bb2030f492e6b57ad7f/);
+  assert.match(workflow, /wardriverBasemapInputContainerName/);
+  assert.match(workflow, /input_container/);
+  assert.match(workflow, /Fetch and verify private Washington input/);
+  assert.match(workflow, /geofabrik\/washington\/washington\.osm\.pbf/);
+  assert.match(workflow, /washington-provenance\.json/);
+  assert.doesNotMatch(workflow, /curl[^\n]*download\.geofabrik\.de/);
   assert.match(workflow, /Fetch and verify pinned private Planetiler toolchain/);
   assert.match(workflow, /--container-name "\$TOOLCHAIN_CONTAINER"/);
   assert.match(workflow, /planetiler\/\$\{PLANETILER_VERSION\}\/planetiler\.jar/);
@@ -89,7 +99,7 @@ test('manual basemap publication verifies its source and toolchain, emits proven
     'the private toolchain must validate before public-host enablement',
   );
   assert.ok(
-    workflow.indexOf('Enable Storage static website') < workflow.indexOf('Fetch and verify bounded OpenStreetMap input'),
+    workflow.indexOf('Enable Storage static website') < workflow.indexOf('Fetch and verify private Washington input'),
     'the public static endpoint must be enabled only after OIDC proof and before tile generation',
   );
   assert.match(workflow, /STYLE_OBJECT_PATH: v1\/style\.json/);


### PR DESCRIPTION
## Change

Replaces the non-existent Geofabrik `.sha256` sidecar with an immutable private, checksum-pinned Washington input plus ODbL/source provenance.

## Evidence

- `node --test tests/*.test.mjs` (168 passed)
- `az bicep build --file infra/main.bicep`
- workflow YAML/Bash syntax parse
- local Washington source hash/provenance canary
- Graphify update/query (workflow YAML was outside useful AST coverage; critical paths were verified directly)

The first protected publication stopped only at the upstream sidecar `404`, after OIDC, private Planetiler retrieval, and `$web` enablement all passed.