### PR TITLE
fix: salvage operator authentication boundary

### DIFF
--- a/api/_lib/operator-auth.js
+++ b/api/_lib/operator-auth.js
@@ -10,11 +10,6 @@ function getConfiguredDigest() {
     return digest;
   }
 
-  const legacyPlaintext = process.env.BLUE_SWALLOW_PASSCODE;
-  if (typeof legacyPlaintext === 'string' && legacyPlaintext.length > 0) {
-    return crypto.createHash('sha256').update(legacyPlaintext, 'utf8').digest('hex');
-  }
-
   return '';
 }
 

--- a/api/_lib/passcode-rate-limit.js
+++ b/api/_lib/passcode-rate-limit.js
@@ -4,7 +4,7 @@ const DEFAULT_MAX_ATTEMPTS = 5;
 const DEFAULT_WINDOW_MS = 5 * 60 * 1000;
 const DEFAULT_TABLE_NAME = 'passcodeFailures';
 const PARTITION_KEY = 'passcode-v1';
-const MAX_MUTATION_RETRIES = 5;
+const MAX_MUTATION_RETRIES = 16;
 
 class PasscodeRateLimitUnavailableError extends Error {
   constructor(message = 'Passcode rate limiting is unavailable.') {
@@ -59,12 +59,19 @@ class AzureTablePasscodeRateLimiter {
     };
   }
 
-  async recordFailure(callerKey, { windowMs, now = Date.now() } = {}) {
+  async reserveAttempt(callerKey, { maxAttempts, windowMs, now = Date.now() } = {}) {
     for (let retry = 0; retry < MAX_MUTATION_RETRIES; retry += 1) {
       const state = await this.#read(callerKey, now);
       if (state.expired) {
         await this.#deleteExpired(callerKey, state.etag);
         continue;
+      }
+
+      if (state.attempts >= maxAttempts) {
+        return {
+          limited: true,
+          retryAfterSeconds: Math.max(1, Math.ceil((state.expiresAtMs - now) / 1000)),
+        };
       }
 
       const entity = {
@@ -74,12 +81,17 @@ class AzureTablePasscodeRateLimiter {
         expiresAt: new Date(state.expiresAtMs || now + windowMs).toISOString(),
       };
       try {
+        let result;
         if (state.exists) {
-          await this.client.updateEntity(entity, 'Replace', { etag: state.etag });
+          result = await this.client.updateEntity(entity, 'Replace', { etag: state.etag });
         } else {
-          await this.client.createEntity(entity);
+          result = await this.client.createEntity(entity);
         }
-        return;
+        return {
+          limited: false,
+          retryAfterSeconds: 0,
+          reservation: { etag: mutationEtag(result) },
+        };
       } catch (error) {
         if (isConcurrencyError(error)) continue;
         throw unavailable(error);
@@ -88,11 +100,13 @@ class AzureTablePasscodeRateLimiter {
     throw unavailable();
   }
 
-  async reset(callerKey) {
+  async reset(callerKey, reservation) {
+    const etag = String(reservation?.etag || '');
+    if (!etag) throw unavailable();
     try {
-      await this.client.deleteEntity(PARTITION_KEY, callerKey, { etag: '*' });
+      await this.client.deleteEntity(PARTITION_KEY, callerKey, { etag });
     } catch (error) {
-      if (isNotFound(error)) return;
+      if (isNotFound(error) || isConcurrencyError(error)) return;
       throw unavailable(error);
     }
   }
@@ -127,9 +141,19 @@ class AzureTablePasscodeRateLimiter {
 function unavailableLimiter(message) {
   return {
     async check() { throw new PasscodeRateLimitUnavailableError(message); },
-    async recordFailure() { throw new PasscodeRateLimitUnavailableError(message); },
+    async reserveAttempt() { throw new PasscodeRateLimitUnavailableError(message); },
     async reset() { throw new PasscodeRateLimitUnavailableError(message); },
   };
+}
+
+function mutationEtag(result) {
+  const direct = result?.etag ?? result?.eTag ?? result?.ETag;
+  if (typeof direct === 'string' && direct) return direct;
+  const headerValue = result?._response?.headers?.get?.('etag')
+    ?? result?.headers?.get?.('etag')
+    ?? result?.headers?.etag;
+  if (typeof headerValue === 'string' && headerValue) return headerValue;
+  throw new PasscodeRateLimitUnavailableError('Passcode rate-limit mutation did not return an ETag.');
 }
 
 function callerKeyForRequest(req) {

--- a/api/validate-passcode/index.js
+++ b/api/validate-passcode/index.js
@@ -38,7 +38,7 @@ module.exports = async function validatePasscode(context, req) {
   const limiter = limiterOverrideForTests || createPasscodeRateLimiter();
   const config = getPasscodeRateLimitConfig();
   try {
-    const rateStatus = await limiter.check(callerKey, config);
+    const rateStatus = await limiter.reserveAttempt(callerKey, config);
     if (rateStatus.limited) {
       context.res = jsonResponse(429, {
         ok: false,
@@ -50,7 +50,7 @@ module.exports = async function validatePasscode(context, req) {
     }
 
     if (verifyPasscode(passcode)) {
-      await limiter.reset(callerKey);
+      await limiter.reset(callerKey, rateStatus.reservation);
       const session = createOperatorToken();
       context.res = jsonResponse(200, {
         ok: true,
@@ -59,7 +59,6 @@ module.exports = async function validatePasscode(context, req) {
       return;
     }
 
-    await limiter.recordFailure(callerKey, config);
     context?.log?.warn?.('Passcode verification failed.', {
       callerKeyPrefix: callerKey.slice(0, 16),
       rateLimitWindowMs: config.windowMs,

--- a/tests/passcode-api.test.mjs
+++ b/tests/passcode-api.test.mjs
@@ -27,9 +27,30 @@ function createTestRateLimiter() {
       const previous = failures.get(callerKey);
       const state = previous && previous.expiresAtMs > now
         ? previous
-        : { attempts: 0, expiresAtMs: now + windowMs };
+        : { attempts: 0, expiresAtMs: now + windowMs, etag: 0 };
       state.attempts += 1;
+      state.etag += 1;
       failures.set(callerKey, state);
+    },
+    async reserveAttempt(callerKey, { maxAttempts, windowMs, now = Date.now() }) {
+      const previous = failures.get(callerKey);
+      const state = previous && previous.expiresAtMs > now
+        ? previous
+        : { attempts: 0, expiresAtMs: now + windowMs, etag: 0 };
+      if (state.attempts >= maxAttempts) {
+        return {
+          limited: true,
+          retryAfterSeconds: Math.max(1, Math.ceil((state.expiresAtMs - now) / 1000)),
+        };
+      }
+      state.attempts += 1;
+      state.etag += 1;
+      failures.set(callerKey, state);
+      return {
+        limited: false,
+        retryAfterSeconds: 0,
+        reservation: { etag: String(state.etag) },
+      };
     },
     async reset(callerKey) {
       failures.delete(callerKey);
@@ -81,7 +102,7 @@ function withEnv(nextEnv, fn) {
     });
 }
 
-test('validate-passcode fails closed when no secret hash or env passcode is configured', async () => {
+test('validate-passcode fails closed when no SHA-256 passcode digest is configured', async () => {
   await withEnv({}, async () => {
     const response = await invoke('blue-swallow');
     assert.equal(response.status, 503);
@@ -143,6 +164,35 @@ test('validate-passcode rate limits repeated failures per caller', async () => {
   });
 });
 
+test('successful passcode authentication clears its current reservation', async () => {
+  const digest = crypto.createHash('sha256').update('clear-current-reservation').digest('hex');
+  await withEnv({
+    BLUE_SWALLOW_PASSCODE_SHA256: digest,
+    BLUE_SWALLOW_OPERATOR_TOKEN_SIGNING_KEY: TEST_SIGNING_KEY,
+    BLUE_SWALLOW_PASSCODE_MAX_ATTEMPTS: '2',
+    BLUE_SWALLOW_PASSCODE_WINDOW_MS: '60000',
+  }, async () => {
+    assert.equal((await invoke('wrong', { ip: '198.51.100.44' })).status, 401);
+    assert.equal((await invoke('clear-current-reservation', { ip: '198.51.100.44' })).status, 200);
+    assert.equal((await invoke('wrong again', { ip: '198.51.100.44' })).status, 401);
+  });
+});
+
+test('validate-passcode reserves before verifying a concurrent burst', async () => {
+  const digest = crypto.createHash('sha256').update('burst-safe passcode').digest('hex');
+  await withEnv({
+    BLUE_SWALLOW_PASSCODE_SHA256: digest,
+    BLUE_SWALLOW_OPERATOR_TOKEN_SIGNING_KEY: TEST_SIGNING_KEY,
+    BLUE_SWALLOW_PASSCODE_MAX_ATTEMPTS: '5',
+    BLUE_SWALLOW_PASSCODE_WINDOW_MS: '60000',
+  }, async () => {
+    const responses = await Promise.all(Array.from({ length: 12 }, () => invoke('wrong', { ip: '198.51.100.91' })));
+    assert.equal(responses.filter((response) => response.status === 401).length, 5);
+    assert.equal(responses.filter((response) => response.status === 429).length, 7);
+    assert.ok(responses.filter((response) => response.status === 429).every((response) => /^\d+$/.test(response.headers['Retry-After'])));
+  });
+});
+
 test('operator token header takes precedence over SWA platform authorization', async () => {
   const digest = crypto.createHash('sha256').update('tzeentch platform auth').digest('hex');
   await withEnv({ BLUE_SWALLOW_PASSCODE_SHA256: digest, BLUE_SWALLOW_OPERATOR_TOKEN_SIGNING_KEY: TEST_SIGNING_KEY }, async () => {
@@ -156,5 +206,42 @@ test('operator token header takes precedence over SWA platform authorization', a
 
     assert.equal(verified.ok, true);
     assert.equal(verified.token.sub, 'operator');
+  });
+});
+
+test('validate-passcode fails closed when only a legacy plaintext passcode is configured', async () => {
+  await withEnv({
+    BLUE_SWALLOW_PASSCODE: 'legacy-only-passcode',
+    BLUE_SWALLOW_OPERATOR_TOKEN_SIGNING_KEY: TEST_SIGNING_KEY,
+  }, async () => {
+    const response = await invoke('legacy-only-passcode');
+    assert.equal(response.status, 503);
+    assert.equal(response.body.ok, false);
+    assert.match(response.body.message, /not configured/i);
+  });
+});
+
+test('validate-passcode fails closed when a malformed digest is accompanied by a legacy plaintext passcode', async () => {
+  await withEnv({
+    BLUE_SWALLOW_PASSCODE_SHA256: 'not-a-sha256-digest',
+    BLUE_SWALLOW_PASSCODE: 'legacy-with-malformed-digest',
+    BLUE_SWALLOW_OPERATOR_TOKEN_SIGNING_KEY: TEST_SIGNING_KEY,
+  }, async () => {
+    const response = await invoke('legacy-with-malformed-digest');
+    assert.equal(response.status, 503);
+    assert.equal(response.body.ok, false);
+    assert.match(response.body.message, /not configured/i);
+  });
+});
+
+test('validate-passcode keeps a valid digest authoritative when a legacy plaintext setting is also present', async () => {
+  const canonicalPasscode = 'canonical-digest-passcode';
+  await withEnv({
+    BLUE_SWALLOW_PASSCODE_SHA256: crypto.createHash('sha256').update(canonicalPasscode).digest('hex'),
+    BLUE_SWALLOW_PASSCODE: 'legacy-shadow-passcode',
+    BLUE_SWALLOW_OPERATOR_TOKEN_SIGNING_KEY: TEST_SIGNING_KEY,
+  }, async () => {
+    assert.equal((await invoke('legacy-shadow-passcode')).status, 401);
+    assert.equal((await invoke(canonicalPasscode)).status, 200);
   });
 });

--- a/tests/passcode-rate-limit.test.mjs
+++ b/tests/passcode-rate-limit.test.mjs
@@ -31,7 +31,9 @@ function createTableClient() {
         error.statusCode = 409;
         throw error;
       }
-      entities.set(key, { ...entity, etag: 'one' });
+      const created = { ...entity, etag: 'one' };
+      entities.set(key, created);
+      return { etag: created.etag };
     },
     async updateEntity(entity, _mode, { etag }) {
       const key = `${entity.partitionKey}:${entity.rowKey}`;
@@ -41,10 +43,83 @@ function createTableClient() {
         error.statusCode = 412;
         throw error;
       }
-      entities.set(key, { ...entity, etag: `${Number(existing.attempts) + 1}` });
+      const updated = { ...entity, etag: `${Number(existing.attempts) + 1}` };
+      entities.set(key, updated);
+      return { etag: updated.etag };
     },
-    async deleteEntity(partitionKey, rowKey) {
-      entities.delete(`${partitionKey}:${rowKey}`);
+    async deleteEntity(partitionKey, rowKey, { etag = '*' } = {}) {
+      const key = `${partitionKey}:${rowKey}`;
+      const existing = entities.get(key);
+      if (!existing) throw notFound();
+      if (etag !== '*' && existing.etag !== etag) {
+        const error = new Error('precondition failed');
+        error.statusCode = 412;
+        throw error;
+      }
+      entities.delete(key);
+    },
+  };
+}
+
+function createBurstTableClient(participants) {
+  const entities = new Map();
+  let firstReads = 0;
+  let releaseFirstReads;
+  const firstReadBarrier = new Promise((resolve) => { releaseFirstReads = resolve; });
+  const counts = { createConflicts: 0, updateConflicts: 0 };
+
+  const conflict = (statusCode) => {
+    const error = new Error('conditional write conflict');
+    error.statusCode = statusCode;
+    return error;
+  };
+
+  return {
+    counts,
+    inspect(partitionKey, rowKey) {
+      return entities.get(`${partitionKey}:${rowKey}`);
+    },
+    async getEntity(partitionKey, rowKey) {
+      const key = `${partitionKey}:${rowKey}`;
+      const firstSnapshot = entities.get(key);
+      if (firstReads < participants) {
+        firstReads += 1;
+        if (firstReads === participants) releaseFirstReads();
+        await firstReadBarrier;
+        if (!firstSnapshot) throw notFound();
+        return { ...firstSnapshot };
+      }
+      const current = entities.get(key);
+      if (!current) throw notFound();
+      return { ...current };
+    },
+    async createEntity(entity) {
+      const key = `${entity.partitionKey}:${entity.rowKey}`;
+      if (entities.has(key)) {
+        counts.createConflicts += 1;
+        throw conflict(409);
+      }
+      const created = { ...entity, etag: 'one' };
+      entities.set(key, created);
+      return { etag: created.etag };
+    },
+    async updateEntity(entity, _mode, { etag }) {
+      const key = `${entity.partitionKey}:${entity.rowKey}`;
+      const current = entities.get(key);
+      if (!current || current.etag !== etag) {
+        counts.updateConflicts += 1;
+        throw conflict(412);
+      }
+      const updated = { ...entity, etag: `${Number(current.attempts) + 1}` };
+      entities.set(key, updated);
+      return { etag: updated.etag };
+    },
+    async deleteEntity(partitionKey, rowKey, { etag = '*' } = {}) {
+      const key = `${partitionKey}:${rowKey}`;
+      const current = entities.get(key);
+      if (!current) throw notFound();
+      if (etag !== '*' && current.etag !== etag) throw conflict(412);
+      entities.delete(key);
     },
   };
 }
@@ -65,13 +140,49 @@ test('Azure Table limiter provides an authoritative failure window and reset', a
   const caller = 'a'.repeat(64);
   const now = Date.UTC(2026, 6, 28);
   assert.deepEqual(await firstInstance.check(caller, { maxAttempts: 2, now }), { limited: false, retryAfterSeconds: 0 });
-  await firstInstance.recordFailure(caller, { windowMs: 60_000, now });
-  await firstInstance.recordFailure(caller, { windowMs: 60_000, now: now + 1 });
+  const firstReservation = await firstInstance.reserveAttempt(caller, { maxAttempts: 2, windowMs: 60_000, now });
+  const secondReservation = await firstInstance.reserveAttempt(caller, { maxAttempts: 2, windowMs: 60_000, now: now + 1 });
+  assert.equal(firstReservation.limited, false);
+  assert.equal(secondReservation.limited, false);
   const limited = await secondInstance.check(caller, { maxAttempts: 2, now: now + 2 });
   assert.equal(limited.limited, true);
   assert.equal(limited.retryAfterSeconds, 60);
-  await secondInstance.reset(caller);
+  await secondInstance.reset(caller, secondReservation.reservation);
   assert.equal((await firstInstance.check(caller, { maxAttempts: 2, now: now + 3 })).limited, false);
+});
+
+test('Azure Table limiter atomically reserves at most the configured concurrent attempt ceiling', async () => {
+  const participantCount = 12;
+  const tableClient = createBurstTableClient(participantCount);
+  const limiter = new AzureTablePasscodeRateLimiter(tableClient);
+  const caller = 'b'.repeat(64);
+  const now = Date.UTC(2026, 7, 15);
+
+  const outcomes = await Promise.all(Array.from({ length: participantCount }, () => limiter.reserveAttempt(caller, {
+    maxAttempts: 5,
+    windowMs: 60_000,
+    now,
+  })));
+
+  assert.equal(outcomes.filter((outcome) => !outcome.limited).length, 5);
+  assert.equal(outcomes.filter((outcome) => outcome.limited).length, 7);
+  assert.ok(outcomes.filter((outcome) => outcome.limited).every((outcome) => outcome.retryAfterSeconds > 0));
+  assert.equal(tableClient.inspect('passcode-v1', caller).attempts, 5);
+  assert.ok(tableClient.counts.createConflicts > 0 || tableClient.counts.updateConflicts > 0);
+});
+
+test('a stale successful reset cannot delete a newer reserved attempt', async () => {
+  const limiter = new AzureTablePasscodeRateLimiter(createTableClient());
+  const caller = 'c'.repeat(64);
+  const now = Date.UTC(2026, 7, 15);
+  const first = await limiter.reserveAttempt(caller, { maxAttempts: 2, windowMs: 60_000, now });
+  const second = await limiter.reserveAttempt(caller, { maxAttempts: 2, windowMs: 60_000, now: now + 1 });
+
+  await limiter.reset(caller, first.reservation);
+  assert.equal((await limiter.check(caller, { maxAttempts: 2, now: now + 2 })).limited, true);
+
+  await limiter.reset(caller, second.reservation);
+  assert.equal((await limiter.check(caller, { maxAttempts: 2, now: now + 3 })).limited, false);
 });
 
 test('missing shared-rate-limit configuration fails closed', async () => {


### PR DESCRIPTION
Salvages the retained authentication slice from superseded omnibus PR #40.

Scope:
- make passcode-attempt reservation atomic;
- require digest-only passcode configuration and remove plaintext fallback;
- retain only the focused passcode API/rate-limit tests.

This is intentionally narrow and implements the retained public/private boundary in #47. It does not carry Morning Brief, OSINT, deployment-control, release-promotion, Graphify, browser-harness, or unrelated experiment changes from #40.

Refs #47
Supersedes the authentication slice of #40.