### PR TITLE
refocus: freeze simple replay-safe Wardriver ingest

### DIFF
--- a/.github/workflows/cybermap-api-ci.yml
+++ b/.github/workflows/cybermap-api-ci.yml
@@ -1,0 +1,27 @@
+name: Cybermap API CI
+
+on:
+  pull_request:
+    paths:
+      - 'vm/cybermap-api/**'
+      - '.github/workflows/cybermap-api-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: vm/cybermap-api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: vm/cybermap-api/package-lock.json
+      - run: npm ci
+      - run: npm test

--- a/docs/personal-observation-ingest.md
+++ b/docs/personal-observation-ingest.md
@@ -1,0 +1,54 @@
+# Personal observation ingest
+
+This document defines the recovery contract for Blue Swallow Wardriver uploads to Society/Cybermap.
+
+## Design rule
+
+Wardriver's local SQLite database is the durable client-side source of truth. Upload does not require a second durable encrypted outbox, client-side receipt reconciliation, or a second progress state machine.
+
+The recovery path intentionally uses the existing `bss.observation_batch.v1` contract. A new protocol version is not required to remove the client-side complexity.
+
+## Stable observation identity
+
+Each Wardriver SQLite observation row has a stable source identity. Wardriver serializes it as:
+
+`wardriver-observation:<sqlite-row-id>`
+
+Society scopes that key to the authenticated source and producer device. The effective observation identity is therefore:
+
+`(source_id, device_id, external_observation_key)`
+
+This allows an uncertain client retry to resend an observation in a different batch without creating a second stored observation.
+
+## Replay semantics
+
+Two independent idempotency layers are deliberate:
+
+1. `idempotency_key` identifies one exact batch request. Repeating the same key with the same body returns the original receipt.
+2. The device-scoped `external_observation_key` identifies each underlying observation. Re-sending the same observation under a new batch key is counted as a duplicate rather than inserted again.
+
+A changed observation reusing the same stable observation key is a conflict and must not silently replace previously stored evidence.
+
+## Client algorithm
+
+Wardriver may use one understandable local acknowledgement watermark:
+
+1. Read a bounded set of SQLite rows after the last acknowledged row.
+2. Serialize them as `bss.observation_batch.v1` observations, preserving the stable row-derived external keys.
+3. POST the batch over the existing Android KeyChain mTLS transport.
+4. On transport failure or an uncertain response, leave the watermark unchanged. A later attempt may replay rows safely.
+5. After a successful Society receipt, advance the watermark only through rows represented by the accepted/duplicate response.
+
+The client does not need a durable encrypted copy of the serialized request because the underlying observations remain in SQLite.
+
+## Authentication
+
+The enrolled Android client certificate is the device authentication mechanism. The private key remains managed by Android KeyChain; Wardriver does not need Azure credentials or direct Key Vault access at runtime.
+
+## Privacy boundary
+
+Only observations personally collected by the operator's Blue Swallow devices participate in bogey inference. External datasets may provide display context or generic enrichment, but they must not create, merge, identify, or label bogeys.
+
+## Compatibility
+
+The existing v2 progress/reconciliation path may remain temporarily for compatibility while the simplified Wardriver path is proven on a physical device. It is not a prerequisite for the recovered upload path and should be pruned only after that path is accepted end-to-end.

--- a/vm/cybermap-api/test/fixtures/wardriver-observation-batch-v1.json
+++ b/vm/cybermap-api/test/fixtures/wardriver-observation-batch-v1.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "bss.observation_batch.v1",
+  "idempotency_key": "batch-00000000-0000-4000-8000-000000000042",
+  "device_id": "wardriver-test-device",
+  "session_id": null,
+  "client_clock": "2026-09-06T20:00:01Z",
+  "redaction_class": "hashed",
+  "retention_class": "hash_only",
+  "observations": [
+    {
+      "external_observation_key": "wardriver-observation:42",
+      "kind": "wifi_ap",
+      "observed_at": "2026-09-06T20:00:00Z",
+      "location": {
+        "latitude": 47.6062,
+        "longitude": -122.3321,
+        "accuracy_m": 8.4,
+        "altitude_m": null
+      },
+      "confidence": 0.82,
+      "payload": {
+        "bssid_hmac": "hmac-sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "rssi_dbm": -67,
+        "frequency_mhz": 2412,
+        "passive_only": true
+      },
+      "provenance": {
+        "collector": "co.blueswallow.wardriver",
+        "app_version": "test"
+      }
+    }
+  ]
+}

--- a/vm/cybermap-api/test/simple-observation-replay.test.mjs
+++ b/vm/cybermap-api/test/simple-observation-replay.test.mjs
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { MemoryObservationStore } from '../src/memory-store.mjs';
+import { hashToken } from '../src/auth.mjs';
+import { validBatch, validObservation, DEVICE_ID, INGEST_TOKEN } from './helpers.mjs';
+
+const SOURCE_ID = 'source-owned-device-1';
+
+function createStore() {
+  return new MemoryObservationStore({
+    credentials: [{
+      device_id: DEVICE_ID,
+      source_id: SOURCE_ID,
+      source_class: 'owned_device',
+      token_sha256: hashToken(INGEST_TOKEN),
+      scopes: ['observations:write'],
+      enabled: true,
+    }],
+    now: () => new Date('2026-09-06T20:00:00.000Z'),
+    randomUuid: (() => {
+      let index = 0;
+      return () => `00000000-0000-4000-8000-${String(++index).padStart(12, '0')}`;
+    })(),
+  });
+}
+
+async function credentialFor(store) {
+  return store.authenticate({
+    deviceId: DEVICE_ID,
+    token: INGEST_TOKEN,
+    requiredScope: 'observations:write',
+  });
+}
+
+function recoveryBatch(idempotencyKey) {
+  return validBatch({
+    idempotency_key: idempotencyKey,
+    observations: [validObservation({
+      external_observation_key: 'wardriver-observation:42',
+    })],
+  });
+}
+
+test('v1 recovery upload needs no progress object and stores a Wardriver row once', async () => {
+  const store = createStore();
+  const credential = await credentialFor(store);
+  const batch = recoveryBatch('batch-00000000-0000-4000-8000-000000000042');
+
+  assert.equal(batch.schema_version, 'bss.observation_batch.v1');
+  assert.equal(Object.hasOwn(batch, 'progress'), false);
+
+  const first = await store.applyBatch({ credential, batch });
+  assert.equal(first.statusCode, 201);
+  assert.equal(first.receipt.schema_version, 'bss.sync_receipt.v1');
+  assert.equal(first.receipt.accepted_count, 1);
+  assert.equal(first.receipt.duplicate_count, 0);
+  assert.equal(Object.hasOwn(first.receipt, 'progress'), false);
+});
+
+test('same SQLite observation replayed under a new batch key is a duplicate', async () => {
+  const store = createStore();
+  const credential = await credentialFor(store);
+
+  const first = await store.applyBatch({
+    credential,
+    batch: recoveryBatch('batch-00000000-0000-4000-8000-000000000042'),
+  });
+  const replayWithNewBatch = await store.applyBatch({
+    credential,
+    batch: recoveryBatch('batch-00000000-0000-4000-8000-000000000043'),
+  });
+
+  assert.equal(first.receipt.accepted_count, 1);
+  assert.equal(replayWithNewBatch.statusCode, 201);
+  assert.equal(replayWithNewBatch.replayed, false);
+  assert.equal(replayWithNewBatch.receipt.accepted_count, 0);
+  assert.equal(replayWithNewBatch.receipt.duplicate_count, 1);
+});
+
+test('exact batch retry returns the original receipt', async () => {
+  const store = createStore();
+  const credential = await credentialFor(store);
+  const batch = recoveryBatch('batch-00000000-0000-4000-8000-000000000044');
+
+  const first = await store.applyBatch({ credential, batch });
+  const replay = await store.applyBatch({ credential, batch });
+
+  assert.equal(first.statusCode, 201);
+  assert.equal(replay.statusCode, 200);
+  assert.equal(replay.replayed, true);
+  assert.deepEqual(replay.receipt, first.receipt);
+});

--- a/vm/cybermap-api/test/wardriver-v1-conformance.test.mjs
+++ b/vm/cybermap-api/test/wardriver-v1-conformance.test.mjs
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import { validateObservationBatch } from '../src/contracts.mjs';
+import { MemoryObservationStore } from '../src/memory-store.mjs';
+import { hashToken } from '../src/auth.mjs';
+
+const fixtureUrl = new URL('./fixtures/wardriver-observation-batch-v1.json', import.meta.url);
+const DEVICE_ID = 'wardriver-test-device';
+const INGEST_TOKEN = 'test-ingest-token-32-bytes-minimum-value';
+
+async function loadFixture() {
+  return JSON.parse(await readFile(fixtureUrl, 'utf8'));
+}
+
+function credential() {
+  return Object.freeze({
+    device_id: DEVICE_ID,
+    source_id: 'wardriver-owned-device',
+    source_class: 'owned_device',
+    token_sha256: hashToken(INGEST_TOKEN),
+    scopes: ['observations:write'],
+    enabled: true,
+  });
+}
+
+test('Wardriver golden v1 batch is accepted without progress state', async () => {
+  const raw = await loadFixture();
+  assert.equal(raw.schema_version, 'bss.observation_batch.v1');
+  assert.equal(Object.hasOwn(raw, 'progress'), false);
+
+  const batch = validateObservationBatch(raw, { now: Date.parse('2026-09-07T00:00:00Z') });
+  assert.equal(batch.observations.length, 1);
+  assert.equal(batch.observations[0].external_observation_key, 'wardriver-observation:42');
+});
+
+test('Wardriver golden observation is replay-safe across a fresh batch key', async () => {
+  const raw = await loadFixture();
+  const first = validateObservationBatch(raw, { now: Date.parse('2026-09-07T00:00:00Z') });
+  const store = new MemoryObservationStore({ credentials: [credential()] });
+  const auth = await store.authenticate({
+    deviceId: DEVICE_ID,
+    token: INGEST_TOKEN,
+    requiredScope: 'observations:write',
+  });
+
+  const applied = await store.applyBatch({ credential: auth, batch: first });
+  assert.equal(applied.statusCode, 201);
+  assert.equal(applied.receipt.accepted_count, 1);
+  assert.equal(applied.receipt.duplicate_count, 0);
+
+  const replayRaw = structuredClone(raw);
+  replayRaw.idempotency_key = 'batch-00000000-0000-4000-8000-000000000043';
+  const replay = validateObservationBatch(replayRaw, { now: Date.parse('2026-09-07T00:00:00Z') });
+  const duplicate = await store.applyBatch({ credential: auth, batch: replay });
+
+  assert.equal(duplicate.statusCode, 201);
+  assert.equal(duplicate.receipt.accepted_count, 0);
+  assert.equal(duplicate.receipt.duplicate_count, 1);
+});


### PR DESCRIPTION
Starts #42 by codifying the recovery contract around the existing `bss.observation_batch.v1` path rather than inventing another protocol version.

This first slice:
- defines SQLite row identity as `wardriver-observation:<row-id>`;
- documents device-scoped observation deduplication and exact-batch idempotency;
- explicitly removes client progress/reconciliation from the recovered path;
- preserves mTLS device authentication and the personal-corpus privacy boundary;
- adds focused MemoryObservationStore tests for exact replay and replay under a new batch key.

The existing v2 path remains untouched for compatibility until the simplified physical-device path is proven.

Refs #42
Cross-repo dependency: blue-swallow-wardriver#36 and #37.